### PR TITLE
Ensure match creates consistent histories

### DIFF
--- a/modules/__tests__/serverRendering-test.js
+++ b/modules/__tests__/serverRendering-test.js
@@ -107,7 +107,7 @@ describe('server rendering', function () {
   })
 
   it('accepts a custom history', function (done) {
-    const history = createMemoryHistory()
+    const history = createMemoryHistory('/dashboard')
     const spy = spyOn(history, 'createLocation').andCallThrough()
 
     match({ history, routes, location: '/dashboard' }, function (error, redirectLocation, renderProps) {
@@ -161,7 +161,7 @@ describe('server rendering', function () {
       done()
     })
   })
-  
+
   it('produces a consistent history', function () {
     match({ routes, location: '/dashboard' }, function (error, redirectLocation, renderProps) {
       renderProps.router.listen(function (location) {

--- a/modules/__tests__/serverRendering-test.js
+++ b/modules/__tests__/serverRendering-test.js
@@ -161,6 +161,15 @@ describe('server rendering', function () {
       done()
     })
   })
+  
+  it('produces a consistent history', function () {
+    match({ routes, location: '/dashboard' }, function (error, redirectLocation, renderProps) {
+      renderProps.router.listen(function (location) {
+        expect(location).toExist()
+        expect(location.pathname).toEqual('/dashboard')
+      })
+    })
+  })
 
   describe('server/client consistency', function () {
     // Just render to static markup here to avoid having to normalize markup.

--- a/modules/match.js
+++ b/modules/match.js
@@ -20,7 +20,17 @@ function match({ history, routes, location, ...options }, callback) {
     'match needs a history or a location'
   )
 
-  history = history ? history : createMemoryHistory(options)
+  // Make our own history
+  if (!history) {
+    // Ensure our history is created with a consistent initial location
+    options = {
+      entries: [ location ],
+      ...options
+    }
+
+    history = createMemoryHistory(options)
+  }
+
   const transitionManager = createTransitionManager(
     history,
     createRoutes(routes)

--- a/modules/match.js
+++ b/modules/match.js
@@ -22,7 +22,7 @@ function match({ history, routes, location, ...options }, callback) {
 
   // Make our own history
   if (!history) {
-    // Ensure our history is created with a consistent initial location
+    // Ensure our history is created with an initial location
     options = {
       entries: [ location ],
       ...options
@@ -36,18 +36,10 @@ function match({ history, routes, location, ...options }, callback) {
     createRoutes(routes)
   )
 
-  let unlisten
-
-  if (location) {
-    // Allow match({ location: '/the/path', ... })
-    location = history.createLocation(location)
-  } else {
-    // Pick up the location from the history via synchronous history.listen
-    // call if needed.
-    unlisten = history.listen(historyLocation => {
-      location = historyLocation
-    })
-  }
+  // Pick up the location from the history via synchronous history.listen call.
+  const unlisten = history.listen(historyLocation => {
+    location = historyLocation
+  })
 
   const router = createRouterObject(history, transitionManager)
   history = createRoutingHistory(history, transitionManager)
@@ -67,9 +59,7 @@ function match({ history, routes, location, ...options }, callback) {
     // Defer removing the listener to here to prevent DOM histories from having
     // to unwind DOM event listeners unnecessarily, in case callback renders a
     // <Router> and attaches another history listener.
-    if (unlisten) {
-      unlisten()
-    }
+    unlisten()
   })
 }
 


### PR DESCRIPTION
Ran into this with react-router-redux: reactjs/react-router-redux#284

If users don't provide a history they create themselves, the history created by `match` doesn't have the same entries as the location provided. This can lead to all sorts of funky behavior.

We'll probably also want to drop [the default location](https://github.com/reactjs/history/blob/86881335c9c544341030321331d17480849b47a9/modules/createMemoryHistory.js#L36) provided by `createMemoryHistory` and throw if an initial location isn't provided.