### PR TITLE
Added condition property to do extra tests on route params, etc.

### DIFF
--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -276,6 +276,76 @@ describe('Router', function () {
 
   })
 
+
+  describe('conditions', function () {
+    it('matches route with condition match', function (done) {
+      class MyComponent extends Component {
+        render() {
+          return <div>{this.props.params.fruit}</div>
+        }
+      }
+
+
+      let conditionCalled = false
+      function condition(match, callback) {
+        conditionCalled = true
+        callback(null, true)
+      }
+
+      render((
+        <Router history={createHistory('/apple')}>
+          <Route path=":fruit" component={MyComponent} condition={condition} />
+        </Router>
+      ), node, function () {
+        expect(node.textContent).toEqual('apple')
+        expect(conditionCalled).toEqual(true)
+        done()
+      })
+    })
+
+
+    it('calls condition on both parent and child routes', function (done) {
+      class Parent extends Component {
+        render() {
+          return <div>{this.props.children}</div>
+        }
+      }
+
+      class Child extends Component {
+        render() {
+          return <h1>{this.props.params.name}</h1>
+        }
+      }
+
+
+      let conditionParentCalled = false
+      function conditionParent(match, callback) {
+        conditionParentCalled = true
+        callback(null, true)
+      }
+
+      let conditionChildCalled = false
+      function conditionChild(match, callback) {
+        conditionChildCalled = true
+        callback(null, true)
+      }
+
+      render((
+        <Router history={createHistory('/apple')}>
+          <Route component={Parent} condition={conditionParent}>
+            <Route path="/:name" component={Child} condition={conditionChild} />
+          </Route>
+        </Router>
+      ), node, function () {
+        expect(node.textContent).toEqual('apple')
+        expect(conditionParentCalled).toEqual(true)
+        expect(conditionChildCalled).toEqual(true)
+        done()
+      })
+    })
+
+  })
+
   describe('render prop', function () {
     it('renders with the render prop', function (done) {
       render((

--- a/modules/__tests__/matchRoutes-test.js
+++ b/modules/__tests__/matchRoutes-test.js
@@ -333,13 +333,13 @@ describe('matchRoutes', function () {
 
   describe('routes with conditions', function () {
     it('matches single route', function (done) {
-      let Condition, conditionCalled = false
+      let Condition, conditionCalled = 0
 
       const routes = [
         Condition = {
           path: '/',
           condition: (match, callback) => {
-            conditionCalled = true
+            conditionCalled++
             callback(null, true)
           }
         }
@@ -348,43 +348,43 @@ describe('matchRoutes', function () {
       matchRoutes(routes, createLocation('/'), function (error, match) {
         expect(match).toExist()
         expect(match.routes).toEqual([ Condition ])
-        expect(conditionCalled).toEqual(true)
+        expect(conditionCalled).toEqual(1)
         done()
       })
     })
 
     it('does not match single route', function (done) {
-      let conditionCalled = false
+      let conditionCalled = 0
 
       const routes = [ {
         path: '/',
         condition: (match, callback) => {
-          conditionCalled = true
+          conditionCalled++
           callback(null, false)
         }
       } ]
 
       matchRoutes(routes, createLocation('/'), function (error, match) {
         expect(match).toNotExist()
-        expect(conditionCalled).toEqual(true)
+        expect(conditionCalled).toEqual(1)
         done()
       })
     })
 
     it('matches nested routes', function (done) {
-      let Parent, Child, parentConditionCalled = false, childConditionCalled = false
+      let Parent, Child, parentConditionCalled = 0, childConditionCalled = 0
 
       const routes = [
         Parent = {
           condition: (match, callback) => {
-            parentConditionCalled = true
+            parentConditionCalled++
             callback(null, true)
           },
           childRoutes: [
             Child = {
               path: '/',
               condition: (match, callback) => {
-                childConditionCalled = true
+                childConditionCalled++
                 callback(null, true)
               }
             }
@@ -395,27 +395,27 @@ describe('matchRoutes', function () {
       matchRoutes(routes, createLocation('/'), function (error, match) {
         expect(match).toExist()
         expect(match.routes).toEqual([ Parent, Child ])
-        expect(parentConditionCalled).toEqual(true)
-        expect(childConditionCalled).toEqual(true)
+        expect(parentConditionCalled).toEqual(1)
+        expect(childConditionCalled).toEqual(1)
         done()
       })
     })
 
     it('does not match nested routes on parent condition failure', function (done) {
-      let parentConditionCalled = false, childConditionCalled = false
+      let parentConditionCalled = 0, childConditionCalled = 0
 
       const routes = [
         {
           path: '/:food/',
           condition: (match, callback) => {
-            parentConditionCalled = true
+            parentConditionCalled++
             callback(null, false)
           },
           childRoutes: [
             {
               path: ':color',
               condition: (match, callback) => {
-                childConditionCalled = true
+                childConditionCalled++
                 callback(null, true)
               }
             }
@@ -425,8 +425,8 @@ describe('matchRoutes', function () {
 
       matchRoutes(routes, createLocation('/apple/orange'), function (error, match) {
         expect(match).toNotExist()
-        expect(parentConditionCalled).toEqual(true)
-        expect(childConditionCalled).toEqual(false)
+        expect(parentConditionCalled).toEqual(1)
+        expect(childConditionCalled).toEqual(0)
         done()
       })
     })

--- a/modules/__tests__/matchRoutes-test.js
+++ b/modules/__tests__/matchRoutes-test.js
@@ -331,6 +331,107 @@ describe('matchRoutes', function () {
     })
   })
 
+  describe('routes with conditions', function () {
+    it('matches single route', function (done) {
+      let Condition, conditionCalled = false
+
+      const routes = [
+        Condition = {
+          path: '/',
+          condition: (match, callback) => {
+            conditionCalled = true
+            callback(null, true)
+          }
+        }
+      ]
+
+      matchRoutes(routes, createLocation('/'), function (error, match) {
+        expect(match).toExist()
+        expect(match.routes).toEqual([ Condition ])
+        expect(conditionCalled).toEqual(true)
+        done()
+      })
+    })
+
+    it('does not match single route', function (done) {
+      let conditionCalled = false
+
+      const routes = [ {
+        path: '/',
+        condition: (match, callback) => {
+          conditionCalled = true
+          callback(null, false)
+        }
+      } ]
+
+      matchRoutes(routes, createLocation('/'), function (error, match) {
+        expect(match).toNotExist()
+        expect(conditionCalled).toEqual(true)
+        done()
+      })
+    })
+
+    it('matches nested routes', function (done) {
+      let Parent, Child, parentConditionCalled = false, childConditionCalled = false
+
+      const routes = [
+        Parent = {
+          condition: (match, callback) => {
+            parentConditionCalled = true
+            callback(null, true)
+          },
+          childRoutes: [
+            Child = {
+              path: '/',
+              condition: (match, callback) => {
+                childConditionCalled = true
+                callback(null, true)
+              }
+            }
+          ]
+        }
+      ]
+
+      matchRoutes(routes, createLocation('/'), function (error, match) {
+        expect(match).toExist()
+        expect(match.routes).toEqual([ Parent, Child ])
+        expect(parentConditionCalled).toEqual(true)
+        expect(childConditionCalled).toEqual(true)
+        done()
+      })
+    })
+
+    it('does not match nested routes on parent condition failure', function (done) {
+      let parentConditionCalled = false, childConditionCalled = false
+
+      const routes = [
+        {
+          path: '/:food/',
+          condition: (match, callback) => {
+            parentConditionCalled = true
+            callback(null, false)
+          },
+          childRoutes: [
+            {
+              path: ':color',
+              condition: (match, callback) => {
+                childConditionCalled = true
+                callback(null, true)
+              }
+            }
+          ]
+        }
+      ]
+
+      matchRoutes(routes, createLocation('/apple/orange'), function (error, match) {
+        expect(match).toNotExist()
+        expect(parentConditionCalled).toEqual(true)
+        expect(childConditionCalled).toEqual(false)
+        done()
+      })
+    })
+  })
+
   describe('invalid route configs', function () {
     let invalidRoutes, errorSpy
 

--- a/modules/__tests__/serverRendering-test.js
+++ b/modules/__tests__/serverRendering-test.js
@@ -56,6 +56,28 @@ describe('server rendering', function () {
     }
   }
 
+  class Category extends Component {
+    render() {
+      return (
+        <div className="Category">
+          <h1>Category</h1>
+          <div>{this.props.params.category}</div>
+        </div>
+      )
+    }
+  }
+
+  class Post extends Component {
+    render() {
+      return (
+        <div className="Post">
+          <h1>Post</h1>
+          <div>{this.props.params.slug}</div>
+        </div>
+      )
+    }
+  }
+
   const DashboardRoute = {
     path: '/dashboard',
     component: Dashboard
@@ -80,10 +102,23 @@ describe('server rendering', function () {
     }
   }
 
+  const CategoryRoute = {
+    path: '/food/:category',
+    condition(params, callback) {
+      callback(null, [ 'baking', 'bbq' ].indexOf(params.category) > -1)
+    },
+    component: Category
+  }
+
+  const PostRoute = {
+    path: '/food/:slug',
+    component: Post
+  }
+
   const routes = {
     path: '/',
     component: App,
-    childRoutes: [ DashboardRoute, AboutRoute, RedirectRoute, AsyncRoute ]
+    childRoutes: [ DashboardRoute, AboutRoute, RedirectRoute, AsyncRoute, CategoryRoute, PostRoute ]
   }
 
   it('works for synchronous route', function (done) {
@@ -198,6 +233,28 @@ describe('server rendering', function () {
           done()
         })
       })
+    })
+  })
+
+  it('condition matches category route', function (done) {
+    match({ routes, location: '/food/bbq' }, function (error, redirectLocation, renderProps) {
+      const string = renderToString(
+        <RouterContext {...renderProps} />
+      )
+      expect(string).toMatch(/Category/)
+      expect(string).toMatch(/bbq/)
+      done()
+    })
+  })
+
+  it('condition does not match and moves to next mached route', function (done) {
+    match({ routes, location: '/food/pizza-hut' }, function (error, redirectLocation, renderProps) {
+      const string = renderToString(
+        <RouterContext {...renderProps} />
+      )
+      expect(string).toMatch(/Post/)
+      expect(string).toMatch(/pizza-hut/)
+      done()
     })
   })
 })

--- a/modules/matchRoutes.js
+++ b/modules/matchRoutes.js
@@ -49,18 +49,19 @@ function getIndexRoute(route, location, callback) {
   }
 }
 
-function checkCondition(condition, params, callback) {
+function checkCondition(condition, paramNames, paramValues, callback) {
   if (!condition) {
     callback(null, true)
   } else {
-    condition(params, callback)
+    const params = createParams(paramNames, paramValues)
+    condition(params, function (error, isMatch) {
+      callback(error, isMatch, params)
+    })
   }
 }
 
 function finalize(route, location, paramNames, paramValues, callback) {
-  const params = createParams(paramNames, paramValues)
-
-  checkCondition(route.condition, params, function (error, isMatch) {
+  checkCondition(route.condition, paramNames, paramValues, function (error, isMatch, params) {
     if (error) {
       callback(error)
     } else if (!isMatch) {
@@ -72,7 +73,7 @@ function finalize(route, location, paramNames, paramValues, callback) {
         } else {
           const match = {
             routes: [ route ],
-            params: params
+            params: params || createParams(paramNames, paramValues)
           }
 
           if (Array.isArray(indexRoute)) {
@@ -97,7 +98,7 @@ function finalize(route, location, paramNames, paramValues, callback) {
 }
 
 function matchChildren(route, location, remainingPathname, paramNames, paramValues, callback) {
-  checkCondition(route.condition, createParams(paramNames, paramValues), function (error, isMatch) {
+  checkCondition(route.condition, paramNames, paramValues, function (error, isMatch) {
     if (error) {
       callback(error)
     } else if (!isMatch) {


### PR DESCRIPTION
This is sort of a WIP of what could be extremely useful for routing.  IMO, there should be a few other methods of doing what I have here, such as a a "requirements" field to do simple regex without the need of creating a function as well as a "defaults" to set param defaults.

I've ran into the need to have more of an ability to match multiple routes and do some sort of check.  I've resorted to insane hacks to get around it.

This PR shows just the "condition" method being used.

```javascript
function isValidCategory(match, callback) {
  callback(null, ['baking', 'bbq'].indexOf(match.params.category) > -1)
}

const routes = (
  <Route path="/" component={App}>
    <IndexRoute component={Home} />
    <Route path=":category(/:page)" component={Category} condition={isValidCategory} />
    <Route path=":slug" component={Page} />
  </Route>
);
```

I haven't dug too much into the code, I just wanted to see how hard it would be to add this functionality, and it turns out that the way I did it didn't take more than 10 minutes to do.