### PR TITLE
[PoC] Use Express-style path matching

### DIFF
--- a/modules/PatternUtils.js
+++ b/modules/PatternUtils.js
@@ -1,79 +1,26 @@
-import invariant from 'invariant'
+import pathToRegexp from 'path-to-regexp'
 
-function escapeRegExp(string) {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
+const RegexpCache = {}
+const CompiledCache = {}
 
-function escapeSource(string) {
-  return escapeRegExp(string).replace(/\/+/g, '/+')
-}
-
-function _compilePattern(pattern) {
-  let regexpSource = ''
-  const paramNames = []
-  const tokens = []
-
-  let match, lastIndex = 0, matcher = /:([a-zA-Z_$][a-zA-Z0-9_$]*)|\*\*|\*|\(|\)/g
-  while ((match = matcher.exec(pattern))) {
-    if (match.index !== lastIndex) {
-      tokens.push(pattern.slice(lastIndex, match.index))
-      regexpSource += escapeSource(pattern.slice(lastIndex, match.index))
-    }
-
-    if (match[1]) {
-      regexpSource += '([^/?#]+)'
-      paramNames.push(match[1])
-    } else if (match[0] === '**') {
-      regexpSource += '([\\s\\S]*)'
-      paramNames.push('splat')
-    } else if (match[0] === '*') {
-      regexpSource += '([\\s\\S]*?)'
-      paramNames.push('splat')
-    } else if (match[0] === '(') {
-      regexpSource += '(?:'
-    } else if (match[0] === ')') {
-      regexpSource += ')?'
-    }
-
-    tokens.push(match[0])
-
-    lastIndex = matcher.lastIndex
+function getRegexp(pattern) {
+  if (!RegexpCache[pattern]) {
+    RegexpCache[pattern] = pathToRegexp(pattern, { end: false })
   }
 
-  if (lastIndex !== pattern.length) {
-    tokens.push(pattern.slice(lastIndex, pattern.length))
-    regexpSource += escapeSource(pattern.slice(lastIndex, pattern.length))
-  }
-
-  return {
-    pattern,
-    regexpSource,
-    paramNames,
-    tokens
-  }
+  return RegexpCache[pattern]
 }
 
-const CompiledPatternsCache = {}
+function getCompiled(pattern) {
+  if (!CompiledCache[pattern]) {
+    CompiledCache[pattern] = pathToRegexp.compile(pattern)
+  }
 
-export function compilePattern(pattern) {
-  if (!(pattern in CompiledPatternsCache))
-    CompiledPatternsCache[pattern] = _compilePattern(pattern)
-
-  return CompiledPatternsCache[pattern]
+  return CompiledCache[pattern]
 }
 
 /**
- * Attempts to match a pattern on the given pathname. Patterns may use
- * the following special characters:
- *
- * - :paramName     Matches a URL segment up to the next /, ?, or #. The
- *                  captured string is considered a "param"
- * - ()             Wraps a segment of the URL that is optional
- * - *              Consumes (non-greedy) all characters up to the next
- *                  character in the pattern, or to the end of the URL if
- *                  there is none
- * - **             Consumes (greedy) all characters up to the next character
- *                  in the pattern, or to the end of the URL if there is none
+ * Attempts to match a pattern on the given pathname.
  *
  * The return value is an object with the following properties:
  *
@@ -90,74 +37,54 @@ export function matchPattern(pattern, pathname) {
     pathname = `/${pathname}`
   }
 
-  let { regexpSource, paramNames, tokens } = compilePattern(pattern)
+  const regexp = getRegexp(pattern)
+  const match = regexp.exec(pathname)
 
-  regexpSource += '/*' // Capture path separators
-
-  // Special-case patterns like '*' for catch-all routes.
-  const captureRemaining = tokens[tokens.length - 1] !== '*'
-
-  if (captureRemaining) {
-    // This will match newlines in the remaining path.
-    regexpSource += '([\\s\\S]*?)'
-  }
-
-  const match = pathname.match(new RegExp('^' + regexpSource + '$', 'i'))
-
-  let remainingPathname, paramValues
-  if (match != null) {
-    if (captureRemaining) {
-      remainingPathname = match.pop()
-      const matchedPath =
-        match[0].substr(0, match[0].length - remainingPathname.length)
-
-      // If we didn't match the entire pathname, then make sure that the match
-      // we did get ends at a path separator (potentially the one we added
-      // above at the beginning of the path, if the actual match was empty).
-      if (
-        remainingPathname &&
-        matchedPath.charAt(matchedPath.length - 1) !== '/'
-      ) {
-        return {
-          remainingPathname: null,
-          paramNames,
-          paramValues: null
-        }
-      }
-    } else {
-      // If this matched at all, then the match was the entire pathname.
-      remainingPathname = ''
+  if (match == null) {
+    return {
+      remainingPathname: null,
+      paramNames: [],
+      paramValues: []
     }
-
-    paramValues = match.slice(1).map(
-      v => v != null ? decodeURIComponent(v) : v
-    )
-  } else {
-    remainingPathname = paramValues = null
   }
 
   return {
-    remainingPathname,
-    paramNames,
-    paramValues
+    remainingPathname: pathname.substr(match[0].length),
+    paramNames: regexp.keys.map(({ name }) => name),
+    paramValues: match.slice(1).map(v => v && decodeURIComponent(v))
   }
 }
 
 export function getParamNames(pattern) {
-  return compilePattern(pattern).paramNames
+  // By assumption we'll have already built the regexp, so better to use the
+  // cached regexp than to use pathToRegexp.parse.
+  return getRegexp(pattern).keys.map(({ name }) => name)
+}
+
+export function makeParams(paramNames, paramValues) {
+  const params = {}
+  let lastIndex = 0
+
+  paramNames.forEach((paramName, index) => {
+    if (typeof paramName === 'number') {
+      paramName = lastIndex++
+    }
+
+    params[paramName] = paramValues && paramValues[index]
+  })
+
+  return params
 }
 
 export function getParams(pattern, pathname) {
-  const { paramNames, paramValues } = matchPattern(pattern, pathname)
+  const { remainingPathname, paramNames, paramValues } =
+    matchPattern(pattern, pathname)
 
-  if (paramValues != null) {
-    return paramNames.reduce(function (memo, paramName, index) {
-      memo[paramName] = paramValues[index]
-      return memo
-    }, {})
+  if (remainingPathname == null) {
+    return null
   }
 
-  return null
+  return makeParams(paramNames, paramValues)
 }
 
 /**
@@ -165,46 +92,5 @@ export function getParams(pattern, pathname) {
  * if there is a dynamic segment of the pattern for which there is no param.
  */
 export function formatPattern(pattern, params) {
-  params = params || {}
-
-  const { tokens } = compilePattern(pattern)
-  let parenCount = 0, pathname = '', splatIndex = 0
-
-  let token, paramName, paramValue
-  for (let i = 0, len = tokens.length; i < len; ++i) {
-    token = tokens[i]
-
-    if (token === '*' || token === '**') {
-      paramValue = Array.isArray(params.splat) ? params.splat[splatIndex++] : params.splat
-
-      invariant(
-        paramValue != null || parenCount > 0,
-        'Missing splat #%s for path "%s"',
-        splatIndex, pattern
-      )
-
-      if (paramValue != null)
-        pathname += encodeURI(paramValue)
-    } else if (token === '(') {
-      parenCount += 1
-    } else if (token === ')') {
-      parenCount -= 1
-    } else if (token.charAt(0) === ':') {
-      paramName = token.substring(1)
-      paramValue = params[paramName]
-
-      invariant(
-        paramValue != null || parenCount > 0,
-        'Missing "%s" parameter for path "%s"',
-        paramName, pattern
-      )
-
-      if (paramValue != null)
-        pathname += encodeURIComponent(paramValue)
-    } else {
-      pathname += token
-    }
-  }
-
-  return pathname.replace(/\/+/g, '/')
+  return getCompiled(pattern)(params)
 }

--- a/modules/__tests__/_bc-isActive-test.js
+++ b/modules/__tests__/_bc-isActive-test.js
@@ -90,7 +90,7 @@ describe('v1 isActive', function () {
         })
       })
 
-      it('is active with extraneous slashes', function (done) {
+      it('is not active with extraneous slashes', function (done) {
         render((
           <Router history={createHistory('/parent/child')}>
             <Route path="/parent">
@@ -98,7 +98,7 @@ describe('v1 isActive', function () {
             </Route>
           </Router>
         ), node, function () {
-          expect(this.history.isActive('/parent////child////')).toBe(true)
+          expect(this.history.isActive('/parent////child////')).toBe(false)
           done()
         })
       })
@@ -288,7 +288,7 @@ describe('v1 isActive', function () {
         })
       })
 
-      it('is active with extraneous slashes', function (done) {
+      it('is not active with extraneous slashes', function (done) {
         render((
           <Router history={createHistory('/parent/child')}>
             <Route path="/parent">
@@ -298,8 +298,8 @@ describe('v1 isActive', function () {
             </Route>
           </Router>
         ), node, function () {
-          expect(this.history.isActive('/parent///child///', null)).toBe(true)
-          expect(this.history.isActive('/parent///child///', null, true)).toBe(true)
+          expect(this.history.isActive('/parent///child///', null)).toBe(false)
+          expect(this.history.isActive('/parent///child///', null, true)).toBe(false)
           done()
         })
       })
@@ -324,7 +324,7 @@ describe('v1 isActive', function () {
         })
       })
 
-      it('is active with extraneous slashes', function (done) {
+      it('is not active with extraneous slashes', function (done) {
         render((
           <Router history={createHistory('/parent/child')}>
             <Route path="/parent">
@@ -336,8 +336,8 @@ describe('v1 isActive', function () {
             </Route>
           </Router>
         ), node, function () {
-          expect(this.history.isActive('/parent///child///', null)).toBe(true)
-          expect(this.history.isActive('/parent///child///', null, true)).toBe(true)
+          expect(this.history.isActive('/parent///child///', null)).toBe(false)
+          expect(this.history.isActive('/parent///child///', null, true)).toBe(false)
           done()
         })
       })

--- a/modules/__tests__/formatPattern-test.js
+++ b/modules/__tests__/formatPattern-test.js
@@ -15,9 +15,7 @@ describe('formatPattern', function () {
 
     describe('and a param is missing', function () {
       it('throws an Error', function () {
-        expect(function () {
-          formatPattern(pattern, {})
-        }).toThrow(Error)
+        expect(() => formatPattern(pattern, {})).toThrow(Error)
       })
     })
 
@@ -82,18 +80,24 @@ describe('formatPattern', function () {
     })
 
     it('complains if not given enough splat values', function () {
-      expect(function () {
-        formatPattern('/a/*/c/*', { 0: 'b' })
-      }).toThrow(Error)
-      expect(function () {
-        formatPattern('/a/*/d/*', { 0: 'b/c/d' })
-      }).toThrow(Error)
+      expect(() => formatPattern('/a/*/c/*', { 0: 'b' })).toThrow(Error)
+      expect(() => formatPattern('/a/*/d/*', { 0: 'b/c/d' })).toThrow(Error)
     })
   })
 
   describe('when a pattern has dots', function () {
     it('returns the correct path', function () {
       expect(formatPattern('/foo.bar.baz')).toEqual('/foo.bar.baz')
+    })
+  })
+
+  describe('when a pattern has regexes for params', function () {
+    it('returns the correct path', function () {
+      expect(formatPattern('/:int(\\d+)', { int: '42' })).toEqual('/42')
+    })
+
+    it('complains if param does not match regex', function () {
+      expect(() => formatPattern('/:int(\\d+)', { int: 'foo' })).toThrow(Error)
     })
   })
 })

--- a/modules/__tests__/formatPattern-test.js
+++ b/modules/__tests__/formatPattern-test.js
@@ -22,19 +22,7 @@ describe('formatPattern', function () {
     })
 
     describe('and a param is optional', function () {
-      const pattern = '/comments/(:id)/edit'
-
-      it('returns the correct path when param is supplied', function () {
-        expect(formatPattern(pattern, { id:'123' })).toEqual('/comments/123/edit')
-      })
-
-      it('returns the correct path when param is not supplied', function () {
-        expect(formatPattern(pattern, {})).toEqual('/comments/edit')
-      })
-    })
-
-    describe('and a param and forward slash are optional', function () {
-      const pattern = '/comments(/:id)/edit'
+      const pattern = '/comments/:id?/edit'
 
       it('returns the correct path when param is supplied', function () {
         expect(formatPattern(pattern, { id:'123' })).toEqual('/comments/123/edit')
@@ -82,31 +70,23 @@ describe('formatPattern', function () {
 
   describe('when a pattern has one splat', function () {
     it('returns the correct path', function () {
-      expect(formatPattern('/a/*/d', { splat: 'b/c' })).toEqual('/a/b/c/d')
+      expect(formatPattern('/a/*/d', { 0: 'b/c' })).toEqual('/a/b%2Fc/d')
     })
   })
 
   describe('when a pattern has multiple splats', function () {
     it('returns the correct path', function () {
-      expect(formatPattern('/a/*/c/*', { splat: [ 'b', 'd' ] })).toEqual('/a/b/c/d')
+      expect(formatPattern('/a/*/c/*', { 0: 'b', 1: 'd' })).toEqual('/a/b/c/d')
+      expect(formatPattern('/a/*/d', { 0: 'b/c/d' })).toEqual('/a/b%2Fc%2Fd/d')
+      expect(formatPattern('/a/*/d/*', { 0: 'b/c/d', 1: 'e' })).toEqual('/a/b%2Fc%2Fd/d/e')
     })
 
     it('complains if not given enough splat values', function () {
       expect(function () {
-        formatPattern('/a/*/c/*', { splat: [ 'b' ] })
+        formatPattern('/a/*/c/*', { 0: 'b' })
       }).toThrow(Error)
-    })
-  })
-
-  describe('when a pattern has a greedy splat', function () {
-    it('returns the correct path', function () {
-      expect(formatPattern('/a/**/d', { splat: 'b/c/d' })).toEqual('/a/b/c/d/d')
-      expect(formatPattern('/a/**/d/**', { splat: [ 'b/c/d', 'e' ] })).toEqual('/a/b/c/d/d/e')
-    })
-
-    it('complains if not given enough splat values', function () {
       expect(function () {
-        formatPattern('/a/**/d/**', { splat: [ 'b/c/d' ] })
+        formatPattern('/a/*/d/*', { 0: 'b/c/d' })
       }).toThrow(Error)
     })
   })

--- a/modules/__tests__/getParamNames-test.js
+++ b/modules/__tests__/getParamNames-test.js
@@ -15,8 +15,8 @@ describe('getParamNames', function () {
   })
 
   describe('when a pattern has a *', function () {
-    it('uses the name "splat"', function () {
-      expect(getParamNames('/files/*.jpg')).toEqual([ 'splat' ])
+    it('uses an anonymous name', function () {
+      expect(getParamNames('/files/*.jpg')).toEqual([ 0 ])
     })
   })
 })

--- a/modules/__tests__/getParams-test.js
+++ b/modules/__tests__/getParams-test.js
@@ -28,23 +28,7 @@ describe('getParams', function () {
     })
 
     describe('and the pattern is optional', function () {
-      const pattern = '/comments/(:id)/edit'
-
-      describe('and the path matches with supplied param', function () {
-        it('returns an object with the params', function () {
-          expect(getParams(pattern, '/comments/123/edit')).toEqual({ id: '123' })
-        })
-      })
-
-      describe('and the path matches without supplied param', function () {
-        it('returns an object with an undefined param', function () {
-          expect(getParams(pattern, '/comments//edit')).toEqual({ id: undefined })
-        })
-      })
-    })
-
-    describe('and the pattern and forward slash are optional', function () {
-      const pattern = '/comments(/:id)/edit'
+      const pattern = '/comments/:id?/edit'
 
       describe('and the path matches with supplied param', function () {
         it('returns an object with the params', function () {
@@ -117,36 +101,25 @@ describe('getParams', function () {
   describe('when a pattern has a *', function () {
     describe('and the path matches', function () {
       it('returns an object with the params', function () {
-        expect(getParams('/files/*', '/files/my/photo.jpg')).toEqual({ splat: 'my/photo.jpg' })
-        expect(getParams('/files/*', '/files/my/photo.jpg.zip')).toEqual({ splat: 'my/photo.jpg.zip' })
-        expect(getParams('/files/*.jpg', '/files/my/photo.jpg')).toEqual({ splat: 'my/photo' })
-        expect(getParams('/files/*.jpg', '/files/my/new\nline.jpg')).toEqual({ splat: 'my/new\nline' })
+        expect(getParams('/files/*', '/files/my/photo.jpg')).toEqual({ 0: 'my/photo.jpg' })
+        expect(getParams('/files/*', '/files/my/photo.jpg.zip')).toEqual({ 0: 'my/photo.jpg.zip' })
+        expect(getParams('/files/*.jpg', '/files/my/photo.jpg')).toEqual({ 0: 'my/photo' })
+
+        expect(getParams('/*/f', '/foo/bar/f')).toEqual({ 0: 'foo/bar' })
       })
     })
 
     describe('and the path does not match', function () {
       it('returns null', function () {
         expect(getParams('/files/*.jpg', '/files/my/photo.png')).toBe(null)
-      })
-    })
-  })
 
-  describe('when a pattern has a **', function () {
-    describe('and the path matches', function () {
-      it('return an object with the params', function () {
-        expect(getParams('/**/f', '/foo/bar/f')).toEqual({ splat: 'foo/bar' })
-      })
-    })
-
-    describe('and the path does not match', function () {
-      it('returns null', function () {
-        expect(getParams('/**/f', '/foo/bar/')).toBe(null)
+        expect(getParams('/*/f', '/foo/bar/')).toBe(null)
       })
     })
   })
 
   describe('when a pattern has an optional group', function () {
-    const pattern = '/archive(/:name)'
+    const pattern = '/archive/:name?'
 
     describe('and the path matches', function () {
       it('returns an object with the params', function () {

--- a/modules/__tests__/isActive-test.js
+++ b/modules/__tests__/isActive-test.js
@@ -100,7 +100,7 @@ describe('isActive', function () {
         })
       })
 
-      it('is active with extraneous slashes', function (done) {
+      it('is not active with extraneous slashes', function (done) {
         render((
           <Router history={createHistory('/parent/child')}>
             <Route path="/parent">
@@ -108,7 +108,7 @@ describe('isActive', function () {
             </Route>
           </Router>
         ), node, function () {
-          expect(this.router.isActive('/parent////child////')).toBe(true)
+          expect(this.router.isActive('/parent////child////')).toBe(false)
           done()
         })
       })
@@ -322,7 +322,7 @@ describe('isActive', function () {
         })
       })
 
-      it('is active with extraneous slashes', function (done) {
+      it('is not active with extraneous slashes', function (done) {
         render((
           <Router history={createHistory('/parent/child')}>
             <Route path="/parent">
@@ -332,8 +332,8 @@ describe('isActive', function () {
             </Route>
           </Router>
         ), node, function () {
-          expect(this.router.isActive('/parent///child///')).toBe(true)
-          expect(this.router.isActive('/parent///child///', true)).toBe(true)
+          expect(this.router.isActive('/parent///child///')).toBe(false)
+          expect(this.router.isActive('/parent///child///', true)).toBe(false)
           done()
         })
       })
@@ -358,7 +358,7 @@ describe('isActive', function () {
         })
       })
 
-      it('is active with extraneous slashes', function (done) {
+      it('is not active with extraneous slashes', function (done) {
         render((
           <Router history={createHistory('/parent/child')}>
             <Route path="/parent">
@@ -370,8 +370,8 @@ describe('isActive', function () {
             </Route>
           </Router>
         ), node, function () {
-          expect(this.router.isActive('/parent///child///')).toBe(true)
-          expect(this.router.isActive('/parent///child///', true)).toBe(true)
+          expect(this.router.isActive('/parent///child///')).toBe(false)
+          expect(this.router.isActive('/parent///child///', true)).toBe(false)
           done()
         })
       })

--- a/modules/__tests__/matchPattern-test.js
+++ b/modules/__tests__/matchPattern-test.js
@@ -11,6 +11,14 @@ describe('matchPattern', function () {
     })
   }
 
+  function assertNoMatch(pattern, pathname) {
+    expect(matchPattern(pattern, pathname)).toEqual({
+      remainingPathname: null,
+      paramNames: [],
+      paramValues: []
+    })
+  }
+
   it('works without params', function () {
     assertMatch('/', '/path', '/path', [], [])
   })
@@ -41,4 +49,16 @@ describe('matchPattern', function () {
     assertMatch('/*/*.jpg', '/files/path/to/file.jpg', '', [ 0, 1 ], [ 'files/path/to', 'file' ])
   })
 
+  it('works with regexes for params', function () {
+    assertMatch('/:int(\\d+)', '/42', '', [ 'int' ], [ '42' ])
+    assertNoMatch('/:int(\\d+)', '/foo')
+    assertMatch('/:id(foo|bar)', '/foo', '', [ 'id' ], [ 'foo' ])
+    assertMatch('/:id(foo|bar)', '/bar', '', [ 'id' ], [ 'bar' ])
+    assertNoMatch('/:id(foo|bar)', '/42')
+  })
+
+  it('works with anonymous params', function () {
+    assertMatch('/(foo|bar)', '/foo', '', [ 0 ], [ 'foo' ])
+    assertMatch('/(foo|bar)', '/bar', '', [ 0 ], [ 'bar' ])
+  })
 })

--- a/modules/__tests__/matchPattern-test.js
+++ b/modules/__tests__/matchPattern-test.js
@@ -12,7 +12,7 @@ describe('matchPattern', function () {
   }
 
   it('works without params', function () {
-    assertMatch('/', '/path', 'path', [], [])
+    assertMatch('/', '/path', '/path', [], [])
   })
 
   it('works with named params', function () {
@@ -26,19 +26,19 @@ describe('matchPattern', function () {
   })
 
   it('works with splat params', function () {
-    assertMatch('/files/*.*', '/files/path.jpg', '', [ 'splat', 'splat' ], [ 'path', 'jpg' ])
+    assertMatch('/files/*.*', '/files/path.jpg', '', [ 0, 1 ], [ 'path', 'jpg' ])
   })
 
   it('ignores trailing slashes', function () {
     assertMatch('/:id', '/path/', '', [ 'id' ], [ 'path' ])
   })
 
-  it('works with greedy splat (**)', function () {
-    assertMatch('/**/g', '/greedy/is/good/g', '', [ 'splat' ], [ 'greedy/is/good' ])
+  it('works with greedy splat', function () {
+    assertMatch('/*/g', '/greedy/is/good/g', '', [ 0 ], [ 'greedy/is/good' ])
   })
 
   it('works with greedy and non-greedy splat', function () {
-    assertMatch('/**/*.jpg', '/files/path/to/file.jpg', '', [ 'splat', 'splat' ], [ 'files/path/to', 'file' ])
+    assertMatch('/*/*.jpg', '/files/path/to/file.jpg', '', [ 0, 1 ], [ 'files/path/to', 'file' ])
   })
 
 })

--- a/modules/__tests__/matchRoutes-test.js
+++ b/modules/__tests__/matchRoutes-test.js
@@ -11,7 +11,8 @@ describe('matchRoutes', function () {
   let
     RootRoute, UsersRoute, UsersIndexRoute, UserRoute, PostRoute, FilesRoute,
     AboutRoute, TeamRoute, ProfileRoute, GreedyRoute, OptionalRoute,
-    OptionalRouteChild, CatchAllRoute
+    OptionalRouteChild, RegexRoute, UnnamedParamsRoute,
+    UnnamedParamsRouteChild, CatchAllRoute
   let createLocation = createMemoryHistory().createLocation
 
   beforeEach(function () {
@@ -70,6 +71,17 @@ describe('matchRoutes', function () {
         childRoutes: [
           OptionalRouteChild = {
             path: 'child'
+          }
+        ]
+      },
+      RegexRoute = {
+        path: '/int/:int(\\d+)'
+      },
+      UnnamedParamsRoute = {
+        path: '/unnamed-params/(foo)',
+        childRoutes: [
+          UnnamedParamsRouteChild = {
+            path: '(bar)'
           }
         ]
       },
@@ -201,6 +213,28 @@ describe('matchRoutes', function () {
       })
     })
 
+    describe('when the location matches a route with param regex', function () {
+      it('matches the correct routes and param', function (done) {
+        matchRoutes(routes, createLocation('/int/42'), function (error, match) {
+          expect(match).toExist()
+          expect(match.routes).toEqual([ RegexRoute ])
+          expect(match.params).toEqual({ int: '42' })
+          done()
+        })
+      })
+    })
+
+    describe('when the location matches nested route with unnamed params', function () {
+      it('matches the correct routes and params', function (done) {
+        matchRoutes(routes, createLocation('/unnamed-params/foo/bar'), function (error, match) {
+          expect(match).toExist()
+          expect(match.routes).toEqual([ UnnamedParamsRoute, UnnamedParamsRouteChild ])
+          expect(match.params).toEqual({ 0: 'foo', 1: 'bar' })
+          done()
+        })
+      })
+    })
+
     describe('when the location does not match any routes', function () {
       it('matches the "catch-all" route', function (done) {
         matchRoutes(routes, createLocation('/not-found'), function (error, match) {
@@ -220,6 +254,14 @@ describe('matchRoutes', function () {
 
       it('matches the "catch-all" route on missing path separators', function (done) {
         matchRoutes(routes, createLocation('/optionalchild'), function (error, match) {
+          expect(match).toExist()
+          expect(match.routes).toEqual([ CatchAllRoute ])
+          done()
+        })
+      })
+
+      it('matches the "catch-all" route on a regex miss', function (done) {
+        matchRoutes(routes, createLocation('/int/foo'), function (error, match) {
           expect(match).toExist()
           expect(match.routes).toEqual([ CatchAllRoute ])
           done()

--- a/modules/__tests__/matchRoutes-test.js
+++ b/modules/__tests__/matchRoutes-test.js
@@ -26,7 +26,7 @@ describe('matchRoutes', function () {
       </Route>
     </Route>
     <Route path="/about" />
-    <Route path="/(optional)">
+    <Route path="/(optional)?">
       <Route path="child" />
     </Route>
     <Route path="*" />
@@ -63,10 +63,10 @@ describe('matchRoutes', function () {
         path: '/about'
       },
       GreedyRoute = {
-        path: '/**/f'
+        path: '/*/f'
       },
       OptionalRoute = {
-        path: '/(optional)',
+        path: '/(optional)?',
         childRoutes: [
           OptionalRouteChild = {
             path: 'child'
@@ -117,7 +117,7 @@ describe('matchRoutes', function () {
         matchRoutes(routes, createLocation('/files/a/b/c.jpg'), function (error, match) {
           expect(match).toExist()
           expect(match.routes).toEqual([ FilesRoute ])
-          expect(match.params).toEqual({ splat: [ 'a', 'b/c' ] })
+          expect(match.params).toEqual({ 0: 'a/b', 1: 'c' })
           done()
         })
       })
@@ -128,7 +128,7 @@ describe('matchRoutes', function () {
         matchRoutes(routes, createLocation('/foo/bar/f'), function (error, match) {
           expect(match).toExist()
           expect(match.routes).toEqual([ GreedyRoute ])
-          expect(match.params).toEqual({ splat: 'foo/bar' })
+          expect(match.params).toEqual({ 0: 'foo/bar' })
           done()
         })
       })

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "history": "^2.0.0",
     "invariant": "^2.0.0",
+    "path-to-regexp": "^1.2.1",
     "warning": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This demonstrates ripping out all of our path matching logic and just using the logic from Express.

This would be a breaking change due to the change to syntax for optional parameters, along with handling for unnamed parameters (e.g. splats).

This would allow using custom regexes (and potentially path arrays for multiple-choice matching) for path parameters, but I haven't added tests demonstrating that yet.

For more details, for how this would work, see:
- http://expressjs.com/en/guide/routing.html
- https://github.com/pillarjs/path-to-regexp#readme