### PR TITLE
Update createRouterHistory.js

### DIFF
--- a/modules/createRouterHistory.js
+++ b/modules/createRouterHistory.js
@@ -5,7 +5,7 @@ const canUseDOM = !!(
 )
 
 export default function (createHistory) {
-  let history
+  let history = {}
   if (canUseDOM)
     history = useRouterHistory(createHistory)()
   return history


### PR DESCRIPTION
Add default value for history to allow server side rendering, otherwise, history is undefined and you run into this issue:

`
node_modules/react-router-redux/lib/index.js:78
  history.listen(function (location) {
          ^
TypeError: Cannot call method 'listen' of undefined
`