### PR TITLE
Add useBeforeUnload by default.

### DIFF
--- a/modules/__tests__/useRouterHistory-test.js
+++ b/modules/__tests__/useRouterHistory-test.js
@@ -14,6 +14,11 @@ describe('useRouterHistory', function () {
     expect(history.__v2_compatible__).toBe(true)
   })
 
+  it('adds beforeunload listeners', function () {
+    const history = useRouterHistory(createHistory)()
+    expect(typeof history.listenBeforeUnload).toBe('function')
+  })
+
   it('passes along options, especially query parsing', function (done) {
     const history = useRouterHistory(createHistory)({
       stringifyQuery() {

--- a/modules/useRouterHistory.js
+++ b/modules/useRouterHistory.js
@@ -1,9 +1,10 @@
 import useQueries from 'history/lib/useQueries'
 import useBasename from 'history/lib/useBasename'
+import useBeforeUnload from 'history/lib/useBeforeUnload'
 
 export default function useRouterHistory(createHistory) {
   return function (options) {
-    const history = useQueries(useBasename(createHistory))(options)
+    const history = useBeforeUnload(useQueries(useBasename(createHistory)))(options)
     history.__v2_compatible__ = true
     return history
   }


### PR DESCRIPTION
Implements suggestion in #3110.

This should be a minor bump, as it adds more cases where `setRouterLeaveHook` will be called. Namely, on "hard leaves" where the user is has the browser navigate to another page or closes the window. 

As @taurose pointed out, this also will stop the BFCache from operating, but [this may be a good thing](https://github.com/reactjs/react-router/issues/837) since it causes some misbehavior anyways.