### PR TITLE
Updating Confirming Navigation docs with info about ES6 API.

### DIFF
--- a/docs/guides/ConfirmingNavigation.md
+++ b/docs/guides/ConfirmingNavigation.md
@@ -1,5 +1,7 @@
 # Confirming Navigation
 
+If you are using ES6 classes, then you can't use mixins and so you need to make use of `history`. You can find an example of "Confirming Navigation" in the [rackt/history repo](https://github.com/rackt/history/blob/master/docs/ConfirmingNavigation.md).
+
 You can prevent a transition from happening or prompt the user before leaving a [route](/docs/Glossary.md#route) with a leave hook.
 
 ```js


### PR DESCRIPTION
Updating docs with the words of a maintainer. See http://stackoverflow.com/questions/35295435/react-router-lifecycle-mixin-depreacted-what-to-use-instead-for-confirming-na/35300791?noredirect=1#comment59208084_35300791