### PR TITLE
[Doc] add example IndexLink for query params

### DIFF
--- a/examples/active-links/app.js
+++ b/examples/active-links/app.js
@@ -17,6 +17,7 @@ class App extends React.Component {
           <li><IndexLink to="/users"      activeStyle={ACTIVE}>/users IndexLink</IndexLink></li>
 
           <li><Link      to="/users/ryan" activeStyle={ACTIVE}>/users/ryan</Link></li>
+          <li><IndexLink      to={{ pathname: '/users/ryan', query: { foo: undefined } }} activeStyle={ACTIVE}>/users/ryan IndexLink</IndexLink></li>
           <li><Link      to={{ pathname: '/users/ryan', query: { foo: 'bar' } }}
                                           activeStyle={ACTIVE}>/users/ryan?foo=bar</Link></li>
 


### PR DESCRIPTION
I just ran into that issue: https://github.com/reactjs/react-router/issues/3151 because of an API somehow hard to find.

I think it can be great to add that example to make that easier to find.