### PR TITLE
Fixed bad link in docs

### DIFF
--- a/docs/guides/ServerRendering.md
+++ b/docs/guides/ServerRendering.md
@@ -8,7 +8,7 @@ Server rendering is a bit different than in a client because you'll want to:
 
 To facilitate these needs, you drop one level lower than the [`<Router>`](/docs/API.md#Router) API with:  
 
-- [`match`](/docs/API.md#match-routes-location-options--cb) to match the routes to a location without rendering
+- [`match`](/docs/API.md#match-routes-location-history-options--cb) to match the routes to a location without rendering
 - `RouterContext` for synchronous rendering of route components
 
 It looks something like this with an imaginary JavaScript server:


### PR DESCRIPTION
https://github.com/reactjs/react-router/blob/master/docs/API.md#match-routes-location-history-options--cb exists, the previous link didn't!