### PR TITLE
Transition bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,10 @@
 ## [HEAD]
 > Unreleased
 
-- Nothing yet!
+- Fixed bug where transition hooks were not called on child routes of
+  parent's whose params changed but the child's did not. ([#3166])
+
+[#3166][https://github.com/reactjs/react-router/pull/3166]
 
 [HEAD]: https://github.com/reactjs/react-router/compare/v2.0.0...HEAD
 

--- a/modules/computeChangedRoutes.js
+++ b/modules/computeChangedRoutes.js
@@ -27,8 +27,16 @@ function computeChangedRoutes(prevState, nextState) {
 
   let leaveRoutes, enterRoutes
   if (prevRoutes) {
+    let parentIsLeaving = false
     leaveRoutes = prevRoutes.filter(function (route) {
-      return nextRoutes.indexOf(route) === -1 || routeParamsChanged(route, prevState, nextState)
+      if (parentIsLeaving) {
+        return true
+      } else {
+        const isLeaving = nextRoutes.indexOf(route) === -1 || routeParamsChanged(route, prevState, nextState)
+        if (isLeaving)
+          parentIsLeaving = true
+        return isLeaving
+      }
     })
 
     // onLeave hooks start at the leaf route.


### PR DESCRIPTION
/users/123/assignments/456
/users/789/assignments/456

The transition hooks were called on assignments, but not users, now it calls them on both.

If a parent route is left/entered, we should leave and enter all the children regardless of their params. Imagine this exact example when you've got a data loading lib that depends on the leaving/entering routes. You'd see user 123's assignment and not user 789's.