### PR TITLE
Update API docs for Link#to

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -107,17 +107,23 @@ A `<Link>` can know when the route it links to is active and automatically apply
 
 #### Props
 ##### `to`
-The path to link to, e.g. `/users/123`.
+Can be either a string or an object.
+* If it's a string it represents the path to link to, e.g. `/users/123`.
+* If it's an object it can have four keys:
+  * `pathname`: A string representing the path to link to.
+  * `query`: An object of key:value pairs to be stringified.
+  * `hash`: A hash to put in the URL, e.g. `#a-hash`.
+  * `state`: State to persist to the `location`.
 
-##### `query`
+##### `query` **([Deprecated](https://github.com/reactjs/react-router/blob/master/upgrade-guides/v2.0.0.md#link-to-onenter-and-isactive-use-location-descriptors) see `to`)**
 An object of key:value pairs to be stringified.
 
-##### `hash`
+##### `hash` **([Deprecated](https://github.com/reactjs/react-router/blob/master/upgrade-guides/v2.0.0.md#link-to-onenter-and-isactive-use-location-descriptors) see `to`)**
 A hash to put in the URL, e.g. `#a-hash`.
 
 _Note: React Router currently does not manage scroll position, and will not scroll to the element corresponding to the hash. Scroll position management utilities are available in the [scroll-behavior](https://github.com/taion/scroll-behavior) library._
 
-##### `state`
+##### `state` **([Deprecated](https://github.com/reactjs/react-router/blob/master/upgrade-guides/v2.0.0.md#link-to-onenter-and-isactive-use-location-descriptors) see `to`)**
 State to persist to the `location`.
 
 ##### `activeClassName`


### PR DESCRIPTION
The `<Link>` API has been updated in 2.0 ([see this](https://github.com/reactjs/react-router/blob/master/upgrade-guides/v2.0.0.md#link-to-onenter-and-isactive-use-location-descriptors)).

The library informs the user via console messages when deprecated attributes are used: ![console](https://cloud.githubusercontent.com/assets/767959/13775417/a8fd2284-eaa4-11e5-8317-0827c0be35b0.jpg)

This PR updates the API docs for `<Link>` to reflect these changes.