### PR TITLE
enable walking up route hierarchy to trigger onEnter

### DIFF
--- a/modules/__tests__/transitionHooks-test.js
+++ b/modules/__tests__/transitionHooks-test.js
@@ -340,4 +340,33 @@ describe('When a router enters a branch', function () {
     })
   })
 
+  describe('and then enters a parent route', function () {
+    it('calls the onEnter hooks of the parent', function (done) {
+      const parentEnterSpy = spyOn(UserRoute, 'onEnter').andCallThrough()
+      const childEnterSpy = spyOn(AssignmentRoute, 'onEnter').andCallThrough()
+      const childLeaveSpy = spyOn(AssignmentRoute, 'onLeave').andCallThrough()
+      const history = createHistory('/users/123/assignments/456')
+
+      const steps = [
+        function () {
+          expect(parentEnterSpy).toHaveBeenCalled()
+          expect(childEnterSpy).toHaveBeenCalled()
+          history.push('/users/123')
+        },
+        function () {
+          expect(childLeaveSpy).toHaveBeenCalled()
+          expect(parentEnterSpy.calls.length).toEqual(2)
+        }
+      ]
+
+      const execNextStep = execSteps(steps, done)
+
+      render(
+        <Router history={history}
+                routes={routes}
+                onUpdate={execNextStep}
+        />, node, execNextStep)
+
+    })
+  })
 })

--- a/modules/computeChangedRoutes.js
+++ b/modules/computeChangedRoutes.js
@@ -42,8 +42,13 @@ function computeChangedRoutes(prevState, nextState) {
     // onLeave hooks start at the leaf route.
     leaveRoutes.reverse()
 
+    const lastRoute = (routes) => (
+      routes[routes.length - 1]
+    )
+
     enterRoutes = nextRoutes.filter(function (route) {
-      return prevRoutes.indexOf(route) === -1 || leaveRoutes.indexOf(route) !== -1
+      const isParentRoute = (nextRoutes.indexOf(route) === (nextRoutes.length - 1)) && (lastRoute(prevRoutes) !== lastRoute(nextRoutes))
+      return prevRoutes.indexOf(route) === -1 || leaveRoutes.indexOf(route) !== -1 || isParentRoute
     })
   } else {
     leaveRoutes = []


### PR DESCRIPTION
[I discovered](https://github.com/reactjs/react-router/issues/2256#issuecomment-192544231) the `onEnter` route hook isn't triggered whenever navigating back up the route hierarchy. This enables triggering `onEnter` when navigating from a child branch to a parent branch.

For example, let's take the following routes:

- `/users/:userId`
- `/users/:userId/assignments/:assignmentId`

Navigating from the latter to the former would not trigger `onEnter` when entering the route. This PR alleviates that problem! It will trigger `onEnter` when you enter a parent route from a child route and will not re-trigger it if you click it again.