### PR TITLE
fix(isActive): fix `b.hasOwnProperty is not a function`

### DIFF
--- a/modules/isActive.js
+++ b/modules/isActive.js
@@ -15,7 +15,7 @@ function deepEqual(a, b) {
 
   if (typeof a === 'object') {
     for (let p in a) {
-      if (!a.hasOwnProperty(p)) {
+      if (!Object.prototype.hasOwnProperty.call(a, p)) {
         continue
       }
 
@@ -23,7 +23,7 @@ function deepEqual(a, b) {
         if (b[p] !== undefined) {
           return false
         }
-      } else if (!b.hasOwnProperty(p)) {
+      } else if (!Object.prototype.hasOwnProperty.call(b, p)) {
         return false
       } else if (!deepEqual(a[p], b[p])) {
         return false


### PR DESCRIPTION
`isActive()` is broken because of changes on https://github.com/sindresorhus/query-string/pull/48 

**Reproduction**
Now, test is faling on newly `npm install` of this repository.