### PR TITLE
Docs: add list of exported PropTypes

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -627,7 +627,14 @@ One or many [`<Route>`](#route)s or [`PlainRoute`](#plainroute)s.
 
 
 ### `PropTypes`
-TODO (Pull Requests Welcome)
+The following objects are exposed as properties of the exported PropTypes object:
+- `falsy`: Checks that a component does not have a prop
+- `history`
+- `location`
+- `component`
+- `components`
+- `route`
+- `routes`
 
 
 ### `useRoutes(createHistory)` (deprecated)


### PR DESCRIPTION
Add list of exported PropTypes.
Specified the behavior of the falsy PropType