### PR TITLE
Don't need to include source in distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "docs",
     "es6",
     "lib",
-    "modules/*.js",
     "umd"
   ],
   "main": "lib/index",


### PR DESCRIPTION
This was previously present to support installing from source.