### PR TITLE
Document lack of support for relative links

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -109,7 +109,7 @@ A `<Link>` can know when the route it links to is active and automatically apply
 ##### `to`
 A [location descriptor](https://github.com/mjackson/history/blob/master/docs/Glossary.md#locationdescriptor). Usually this is a string or an object, with the following semantics:
 
-* If it's a string it represents the path to link to, e.g. `/users/123`.
+* If it's a string it represents the absolute path to link to, e.g. `/users/123` (relative paths are not supported).
 * If it's an object it can have four keys:
   * `pathname`: A string representing the path to link to.
   * `query`: An object of key:value pairs to be stringified.


### PR DESCRIPTION
New users assume Link tags are basically equivalent to A tags. It is a rude awakening to discover relative links do not work.