### PR TITLE
Add example for async auth with querystring params

### DIFF
--- a/examples/auth-flow-async-with-query-params/app.js
+++ b/examples/auth-flow-async-with-query-params/app.js
@@ -1,0 +1,97 @@
+import React, { createClass, PropTypes } from 'react'
+import { render } from 'react-dom'
+import { Router, Route, IndexRoute, browserHistory, Link } from 'react-router'
+
+function App(props) {
+  return (
+    <div>
+      {props.children}
+    </div>
+  )
+}
+
+const Form = createClass({
+  contextTypes: {
+    router: PropTypes.object.isRequired
+  },
+
+  getInitialState() {
+    return {
+      value: ''
+    }
+  },
+
+  submitAction(event) {
+    event.preventDefault()
+    this.context.router.push({
+      pathname: '/page',
+      query: {
+        qsparam: this.state.value
+      }
+    })
+  },
+
+  handleChange(event) {
+    this.setState({ value: event.target.value })
+  },
+
+  render() {
+    return (
+      <form onSubmit={this.submitAction}>
+        <p>Token is <em>pancakes</em></p>
+        <input type="text" value={this.state.value} onChange={this.handleChange} />
+        <button type="submit">Submit the thing</button>
+        <p><Link to="/page?qsparam=pancakes">Or authenticate via URL</Link></p>
+        <p><Link to="/page?qsparam=bacon">Or try failing to authenticate via URL</Link></p>
+      </form>
+    )
+  }
+})
+
+function Page() {
+  return <h1>Hey I see you are authenticated.</h1>
+}
+
+function ErrorPage() {
+  return <h1>Oh no! your auth failed!</h1>
+}
+
+function requireCredentials(nextState, replace, next) {
+  const query = nextState.location.query
+  if (query.qsparam) {
+    serverAuth(query.qsparam)
+    .then(
+      () => next(),
+      () => {
+        replace('/error')
+        next()
+      }
+    )
+  } else {
+    replace('/error')
+    next()
+  }
+}
+
+function serverAuth(authToken) {
+  return new Promise((resolve, reject) => {
+    // That server is gonna take a while
+    setTimeout(() => {
+      if(authToken === 'pancakes') {
+        resolve('authenticated')
+      } else {
+        reject('nope')
+      }
+    }, 200)
+  })
+}
+
+render((
+  <Router history={browserHistory}>
+    <Route path="/" component={App}>
+      <IndexRoute component={Form} />
+      <Route path="page" component={Page} onEnter={requireCredentials}/>
+      <Route path="error" component={ErrorPage}/>
+    </Route>
+  </Router>
+), document.getElementById('example'))

--- a/examples/auth-flow-async-with-query-params/index.html
+++ b/examples/auth-flow-async-with-query-params/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base href="/auth-flow-async-with-query-params"/>
+    <meta charset="utf-8">
+    <title>Authentication with query parameters</title>
+    <link rel="stylesheet" href="/global.css"/>
+  </head>
+  <body>
+    <h1 class="breadcrumbs"><a href="/">React Router Examples</a> / Async Auth with Query Parameters</h1>
+    <div id="example"/>
+    <script src="/__build__/shared.js"></script>
+    <script src="/__build__/auth-flow-async-with-query-params.js"></script>
+  </body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -8,6 +8,7 @@
 <li><a href="animations">Animations</a></li>
 <li><a href="auth-flow">Auth Flow</a></li>
 <li><a href="auth-with-shared-root">Auth with Shared Root</a></li>
+<li><a href="auth-flow-async-with-query-params">Async Auth with Query Parameters</a></li>
 <li><a href="breadcrumbs">Breadcrumbs</a></li>
 <li><a href="confirming-navigation">Confirming Navigation</a></li>
 <li><a href="dynamic-segments">Dynamic Segments</a></li>


### PR DESCRIPTION
Simple workflow that uses querystring parameters to determine if a user can look at a page or not. Parameters can come from a form submission, or from an url with those parameters in.

While I understand this is definitely not the best way to do any sort of authentication, I was recently working on an [app](http://contentful.github.io/discovery-app-react/) where this was desirable.

I extracted this flow out of that small app where the usage workflow can be something like:
- new user comes in and uses the form to authenticate
- user can then share the url with the auth parameters in the querystring if desired

If this is too much for an example I can try and slim it down to an async onEnter example, as that is my main reasoning for adding this. As far as I can tell there is currently no example which demonstrates that.