### PR TITLE
Adds example to show "page not found" implementation

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -17,5 +17,6 @@
 <li><a href="passing-props-to-children">Passing Props to Children</a></li>
 <li><a href="pinterest">Pinterest-style UI (<code>location.state</code>)</a></li>
 <li><a href="query-params">Query Params</a></li>
+<li><a href="route-no-match">Route Not Found</a></li>
 <li><a href="sidebar">Sidebar</a></li>
 </ul>

--- a/examples/route-no-match/app.js
+++ b/examples/route-no-match/app.js
@@ -1,0 +1,53 @@
+import React from 'react'
+import { render } from 'react-dom'
+import { browserHistory, Router, Route, Link } from 'react-router'
+
+class User extends React.Component {
+  render() {
+    let { userID } = this.props.params
+    let { query } = this.props.location
+    let age = query && query.showAge ? '33' : ''
+
+    return (
+      <div className="User">
+        <h1>User id: {userID}</h1>
+        {age}
+      </div>
+    )
+  }
+}
+
+class App extends React.Component {
+  render() {
+    return (
+      <div>
+        <ul>
+          <li><Link to="/user/bob" activeClassName="active">Bob</Link></li>
+          <li><Link to={{ pathname: '/user/bob', query: { showAge: true } }} activeClassName="active">Bob With Query Params</Link></li>
+          <li><Link to="/user/sally" activeClassName="active">Sally</Link></li>
+        </ul>
+        {this.props.children}
+      </div>
+    )
+  }
+}
+
+class PageNotFound extends React.Component {
+  render() {
+    return (
+      <div>
+        <h1>Page Not Found.<h1>
+        <p>Go to <Link to="/">Home Page</Link></p>
+      </div>
+    )
+  }
+}
+
+render((
+  <Router history={browserHistory}>
+    <Route path="/" component={App}>
+      <Route path="user/:userID" component={User} />
+    </Route>
+    <Route path="*" component={PageNotFound} />
+  </Router>
+), document.getElementById('example'))

--- a/examples/route-no-match/app.js
+++ b/examples/route-no-match/app.js
@@ -36,7 +36,7 @@ class PageNotFound extends React.Component {
   render() {
     return (
       <div>
-        <h1>Page Not Found.<h1>
+        <h1>Page Not Found.</h1>
         <p>Go to <Link to="/">Home Page</Link></p>
       </div>
     )

--- a/examples/route-no-match/index.html
+++ b/examples/route-no-match/index.html
@@ -1,0 +1,9 @@
+<!doctype html public "restroom">
+<title>Route Not Found Example</title>
+<base href="/route-no-match"/>
+<link href="/global.css" rel="stylesheet"/>
+<body>
+<h1 class="breadcrumbs"><a href="/">React Router Examples</a> / Route Not Found</h1>
+<div id="example"/>
+<script src="/__build__/shared.js"></script>
+<script src="/__build__/route-no-match.js"></script>


### PR DESCRIPTION
* Hope I have done is correct! This example will help to show "page not found" implementation on client side. Refs my comments on https://github.com/reactjs/react-router/issues/458

* If its correct then I would like to update the doc too for Page not found on client side. It might help in https://github.com/reactjs/react-router/issues/2933 fix "Document how to make a client-side "not found" route (i.e. with <Route path="*" component={NotFound} />)" under Potential Improvements
