### PR TITLE
Update basename example

### DIFF
--- a/docs/guides/Histories.md
+++ b/docs/guides/Histories.md
@@ -154,7 +154,7 @@ import { useRouterHistory } from 'react-router'
 import { createHistory } from 'history'
 
 const history = useRouterHistory(createHistory)({
-  basename: 'base-path'
+  basename: '/base-path'
 })
 ```
 


### PR DESCRIPTION
This commit simply adds a preceeding forward slash to the basename example. In my testing (using `v2.0.1`) this is necessary for the basename routing to be applied correctly and adding this to the documentation may provide a bit more clarity for others using the basename option.