### PR TITLE
imported 'createClass' so we don't have to use React.createClass

### DIFF
--- a/modules/IndexLink.js
+++ b/modules/IndexLink.js
@@ -1,10 +1,10 @@
-import React from 'react'
+import React, { createClass } from 'react'
 import Link from './Link'
 
 /**
  * An <IndexLink> is used to link to an <IndexRoute>.
  */
-const IndexLink = React.createClass({
+const IndexLink = createClass({
 
   render() {
     return <Link {...this.props} onlyActiveOnIndex={true} />

--- a/modules/IndexRedirect.js
+++ b/modules/IndexRedirect.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { createClass } from 'react'
 import warning from './routerWarning'
 import invariant from 'invariant'
 import Redirect from './Redirect'
@@ -9,7 +9,7 @@ const { string, object } = React.PropTypes
 /**
  * An <IndexRedirect> is used to redirect from an indexRoute.
  */
-const IndexRedirect = React.createClass({
+const IndexRedirect = createClass({
 
   statics: {
 

--- a/modules/Link.js
+++ b/modules/Link.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { createClass } from 'react'
 import warning from './routerWarning'
 
 const { bool, object, string, func, oneOfType } = React.PropTypes
@@ -46,7 +46,7 @@ function createLocationDescriptor(to, { query, hash, state }) {
  *
  *   <Link ... query={{ show: true }} state={{ the: 'state' }} />
  */
-const Link = React.createClass({
+const Link = createClass({
 
   contextTypes: {
     router: object

--- a/modules/Redirect.js
+++ b/modules/Redirect.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { createClass } from 'react'
 import invariant from 'invariant'
 import { createRouteFromReactElement } from './RouteUtils'
 import { formatPattern } from './PatternUtils'
@@ -13,10 +13,10 @@ const { string, object } = React.PropTypes
  * Redirects are placed alongside routes in the route configuration
  * and are traversed in the same manner.
  */
-const Redirect = React.createClass({
+const Redirect = createClass({
 
   statics: {
-    
+
     createRouteFromReactElement(element) {
       const route = createRouteFromReactElement(element)
 

--- a/modules/Route.js
+++ b/modules/Route.js
@@ -15,7 +15,7 @@ const { string, func } = React.PropTypes
  * that lead to it are considered "active" and their components are
  * rendered into the DOM, nested in the same order as in the tree.
  */
-const Route = React.createClass({
+const Route = createClass({
 
   statics: {
     createRouteFromReactElement

--- a/modules/Route.js
+++ b/modules/Route.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { createClass } from 'react'
 import invariant from 'invariant'
 import { createRouteFromReactElement } from './RouteUtils'
 import { component, components } from './PropTypes'
@@ -15,7 +15,7 @@ const { string, func } = React.PropTypes
  * that lead to it are considered "active" and their components are
  * rendered into the DOM, nested in the same order as in the tree.
  */
-const Route = React.createClass({ 
+const Route = React.createClass({
 
   statics: {
     createRouteFromReactElement

--- a/modules/Router.js
+++ b/modules/Router.js
@@ -1,6 +1,6 @@
 import createHashHistory from 'history/lib/createHashHistory'
 import useQueries from 'history/lib/useQueries'
-import React from 'react'
+import React, { createClass } from 'react'
 
 import createTransitionManager from './createTransitionManager'
 import { routes } from './PropTypes'
@@ -20,7 +20,7 @@ const { func, object } = React.PropTypes
  * a router that renders a <RouterContext> with all the props
  * it needs each time the URL changes.
  */
-const Router = React.createClass({
+const Router = createClass({
 
   propTypes: {
     history: object,

--- a/modules/RouterContext.js
+++ b/modules/RouterContext.js
@@ -1,5 +1,5 @@
 import invariant from 'invariant'
-import React, { createClass} from 'react'
+import React, { createClass } from 'react'
 
 import deprecateObjectProperties from './deprecateObjectProperties'
 import getRouteParams from './getRouteParams'

--- a/modules/RouterContext.js
+++ b/modules/RouterContext.js
@@ -1,5 +1,5 @@
 import invariant from 'invariant'
-import React from 'react'
+import React, { createClass} from 'react'
 
 import deprecateObjectProperties from './deprecateObjectProperties'
 import getRouteParams from './getRouteParams'
@@ -12,7 +12,7 @@ const { array, func, object } = React.PropTypes
  * A <RouterContext> renders the component tree for a given router state
  * and sets the history object and the current location in context.
  */
-const RouterContext = React.createClass({
+const RouterContext = createClass({
 
   propTypes: {
     history: object,

--- a/modules/RoutingContext.js
+++ b/modules/RoutingContext.js
@@ -1,8 +1,8 @@
-import React from 'react'
+import React, { createClass } from 'react'
 import RouterContext from './RouterContext'
 import warning from './routerWarning'
 
-const RoutingContext = React.createClass({
+const RoutingContext = createClass({
   componentWillMount() {
     warning(false, '`RoutingContext` has been renamed to `RouterContext`. Please use `import { RouterContext } from \'react-router\'`. http://tiny.cc/router-routercontext')
   },


### PR DESCRIPTION
Imported createClass from import to save space. Could have been done with PropTypes and so on too, but this would result in name collision, as PropTypes has both internal modules and react modules, I believe.