### PR TITLE
Fixes to PropTypes

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import warning from './routerWarning'
+import { to } from './PropTypes'
 
-const { bool, object, string, func, oneOfType } = React.PropTypes
+const { bool, object, string, func } = React.PropTypes
 
 function isLeftClickEvent(event) {
   return event.button === 0
@@ -53,7 +54,7 @@ const Link = React.createClass({
   },
 
   propTypes: {
-    to: oneOfType([ string, object ]).isRequired,
+    to: to.isRequired,
     query: object,
     hash: string,
     state: object,

--- a/modules/PropTypes.js
+++ b/modules/PropTypes.js
@@ -26,6 +26,7 @@ export const component = oneOfType([ func, string ])
 export const components = oneOfType([ component, object ])
 export const route = oneOfType([ object, element ])
 export const routes = oneOfType([ route, arrayOf(route) ])
+export const to = oneOfType([ string, object ])
 
 export default {
   falsy,
@@ -33,5 +34,6 @@ export default {
   location,
   component,
   components,
-  route
+  route,
+  to
 }


### PR DESCRIPTION
Don't really know why 'oneOfType' is left alone in 'Link' while others are defined in 'PropTypes.js'.
Found it cleaner to remove 'oneOfType' from Link and describe it in PropTypes as the others. Sure @taion or @timdorr has some input on why this is bad, but was worth as shot.

Also, I didn't find this to collide with #3218 

=======

Lastly; I'm sorry for so many PR's. I learn from your replies, which helps me to be a better programmer, writing future code. I'm very thankful for you answering PR's instead of just closing them, which would be quite tempting, as you get a lot of issues and PR's that's not right. 