### PR TITLE
Removed unnecessary className on Link

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -66,7 +66,6 @@ const Link = React.createClass({
   getDefaultProps() {
     return {
       onlyActiveOnIndex: false,
-      className: '',
       style: {}
     }
   },
@@ -119,7 +118,7 @@ const Link = React.createClass({
       if (activeClassName || (activeStyle != null && !isEmptyObject(activeStyle))) {
         if (router.isActive(location, onlyActiveOnIndex)) {
           if (activeClassName)
-            props.className += props.className === '' ? activeClassName : ` ${activeClassName}`
+            props.className = `${props.className || ''} ${activeClassName}`.trim()
 
           if (activeStyle)
             props.style = { ...props.style, ...activeStyle }

--- a/modules/__tests__/Link-test.js
+++ b/modules/__tests__/Link-test.js
@@ -29,6 +29,15 @@ describe('A <Link>', function () {
     node = document.createElement('div')
   })
 
+  it('should not render unnecessary class=""', function () {
+    render((
+      <Link to="/something" />
+    ), node, function () {
+      const a = node.querySelector('a')
+      expect(a.hasAttribute('class')).toBe(false)
+    })
+  })
+
   it('knows how to make its href', function () {
     class LinkWrapper extends Component {
       render() {


### PR DESCRIPTION
`<Link />` always adds the `class=""` attribute even when it's not defined or is active. When you do server rendering you don't want unnecessary attributes.