### PR TITLE
Check for exact path match before checking routes

### DIFF
--- a/modules/__tests__/isActive-test.js
+++ b/modules/__tests__/isActive-test.js
@@ -114,6 +114,12 @@ describe('isActive', function () {
         })
       })
 
+      // This test case is a bit odd. A route with path /parent/child/ won't
+      // match /parent/child because of the trailing slash mismatch. However,
+      // this doesn't matter in practice, since it only comes up if your
+      // isActive pattern has a trailing slash but your route pattern doesn't,
+      // which would be an utterly bizarre thing to do.
+
       it('is active with trailing slash on pattern', function (done) {
         render((
           <Router history={createHistory('/parent/child')}>


### PR DESCRIPTION
Now that we've finally landed #3158 (hopefully for good), we can optimize `isActive` a bit.

Paths are fully canonical now except for possibly the trailing slash.

Thus, for checking `indexOnly` active state, we only need to verify that the paths are the same, net of leading/trailing slash normalization. This ought to be a lot faster than actually running the path match.

Additionally, this condition is also sufficient (but not necessary) for a route match in the general case.