### PR TITLE
Fix references to PropTypes.router

### DIFF
--- a/upgrade-guides/v2.0.0.md
+++ b/upgrade-guides/v2.0.0.md
@@ -160,7 +160,7 @@ const RouteComponent = React.createClass({
 // v2.0.0
 const RouteComponent = React.createClass({
   contextTypes: {
-    router: Router.PropTypes.router.isRequired
+    router: React.PropTypes.object.isRequired
   },
   componentDidMount() {
     const { route } = this.props
@@ -204,7 +204,7 @@ const RouteComponent = React.createClass({
 // v2.0.0
 const RouteComponent = React.createClass({
   contextTypes: {
-    router: Router.PropTypes.router.isRequired
+    router: React.PropTypes.object.isRequired
   },
   someHandler() {
     this.context.router.push(...)
@@ -229,7 +229,7 @@ const DeepComponent = React.createClass({
 // 1) Use context.router (especially if on the server)
 const DeepComponent = React.createClass({
   contextTypes: {
-    router: Router.PropTypes.router.isRequired
+    router: React.PropTypes.object.isRequired
   },
   handleSubmit() {
     this.context.router.push(...)  


### PR DESCRIPTION
`Router.PropTypes.router` is `undefined`. The tutorial uses `React.PropTypes.object`, and which seems to work properly