### PR TITLE
[DO NOT MERGE] Deprecate nested routes with absolute paths

### DIFF
--- a/modules/__tests__/isActive-test.js
+++ b/modules/__tests__/isActive-test.js
@@ -6,6 +6,7 @@ import IndexRoute from '../IndexRoute'
 import Router from '../Router'
 import Route from '../Route'
 import qs from 'qs'
+import shouldWarn from './shouldWarn'
 
 describe('isActive', function () {
 
@@ -195,6 +196,10 @@ describe('isActive', function () {
   })
 
   describe('a pathname that matches a parent route, but not the URL directly', function () {
+    beforeEach(() => {
+      shouldWarn('deprecated')
+    })
+
     describe('with no query', function () {
       it('is active', function (done) {
         render((
@@ -257,6 +262,10 @@ describe('isActive', function () {
   })
 
   describe('a pathname that matches a nested absolute path', function () {
+    beforeEach(() => {
+      shouldWarn('deprecated')
+    })
+
     describe('with no query', function () {
       it('is active', function (done) {
         render((

--- a/modules/__tests__/matchRoutes-test.js
+++ b/modules/__tests__/matchRoutes-test.js
@@ -11,8 +11,7 @@ describe('matchRoutes', function () {
   let routes
   let
     RootRoute, UsersRoute, UsersIndexRoute, UserRoute, PostRoute, FilesRoute,
-    AboutRoute, TeamRoute, ProfileRoute, GreedyRoute, OptionalRoute,
-    OptionalRouteChild, CatchAllRoute
+    AboutRoute, GreedyRoute, OptionalRoute, OptionalRouteChild, CatchAllRoute
   let createLocation = createMemoryHistory().createLocation
 
   beforeEach(function () {
@@ -20,10 +19,7 @@ describe('matchRoutes', function () {
     <Route>
       <Route path="users">
         <IndexRoute />
-        <Route path=":userID">
-          <Route path="/profile" />
-        </Route>
-        <Route path="/team" />
+        <Route path=":userID" />
       </Route>
     </Route>
     <Route path="/about" />
@@ -42,16 +38,10 @@ describe('matchRoutes', function () {
               UserRoute = {
                 path: ':userID',
                 childRoutes: [
-                  ProfileRoute = {
-                    path: '/profile'
-                  },
                   PostRoute = {
                     path: ':postID'
                   }
                 ]
-              },
-              TeamRoute = {
-                path: '/team'
               }
             ]
           }
@@ -234,6 +224,13 @@ describe('matchRoutes', function () {
 
     describe('when the location matches a nested absolute route', function () {
       it('matches the correct routes', function (done) {
+        shouldWarn('deprecated')
+
+        const TeamRoute = {
+          path: '/team'
+        }
+        UsersRoute.childRoutes.push(TeamRoute)
+
         matchRoutes(routes, createLocation('/team'), function (error, match) {
           expect(match).toExist()
           expect(match.routes).toEqual([ RootRoute, UsersRoute, TeamRoute ])
@@ -244,6 +241,13 @@ describe('matchRoutes', function () {
 
     describe('when the location matches an absolute route nested under a route with params', function () {
       it('matches the correct routes and params', function (done) {
+        shouldWarn('deprecated')
+
+        const ProfileRoute = {
+          path: '/profile'
+        }
+        UserRoute.childRoutes.push(ProfileRoute)
+
         matchRoutes(routes, createLocation('/profile'), function (error, match) {
           expect(match).toExist()
           expect(match.routes).toEqual([ RootRoute, UsersRoute, UserRoute, ProfileRoute ])

--- a/modules/isActive.js
+++ b/modules/isActive.js
@@ -75,6 +75,8 @@ function routeIsActive(pathname, routes, params) {
     const pattern = route.path || ''
 
     if (pattern.charAt(0) === '/') {
+      // This code path is deprecated, but we the deprecation warning will
+      // actually be hit from matchRoutes, not from here.
       remainingPathname = pathname
       paramNames = []
       paramValues = []

--- a/modules/matchRoutes.js
+++ b/modules/matchRoutes.js
@@ -80,6 +80,13 @@ function matchRouteDeep(
   let pattern = route.path || ''
 
   if (pattern.charAt(0) === '/') {
+    if (remainingPathname !== location.pathname) {
+      warning(
+        false,
+        'Nested routes with absolute paths are deprecated. Nest those routes under pathless routes instead. http://tiny.cc/router-decouple-ui'
+      )
+    }
+
     remainingPathname = location.pathname
     paramNames = []
     paramValues = []


### PR DESCRIPTION
From @ryanflorence on https://github.com/reactjs/react-router/pull/3246#issuecomment-210139897:

> Added the 3.0 milestone. We don't want to release this until we have features/improvements that depend on it, otherwise it's just annoying to our users. If we get those going we can move this to an earlier release.

> @taion, mind enumerating the feature(s) that depend on this?

So I think at the end of it all, it looks like nothing strictly depends on this. It just makes a lot of things simpler, like relative link support, and lets us further optimize checking whether links are active.

So there's nothing strictly requiring this any more, but we should still do it sooner or later.