### PR TITLE
Restore default PropTypes export (fixes #3342)

### DIFF
--- a/modules/PropTypes.js
+++ b/modules/PropTypes.js
@@ -40,7 +40,10 @@ export const router = shape({
 })
 
 export default {
+  falsy,
   history,
   location,
-  router
+  component,
+  components,
+  route
 }


### PR DESCRIPTION
This addresses a regression in react-router version 2.2.0 where the default export of `PropTypes` had some useful shapes removed. Fixes #3342.