### PR TITLE
Expanded API docs for `context.router`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -165,11 +165,52 @@ An `<IndexLink>` is like a [`<Link>`](#link), except it is only active when the 
 ### `<RouterContext>`
 A `<RouterContext>` renders the component tree for a given router state. Its used by `<Router>` but also useful for server rendering and integrating in brownfield development.
 
-It also provides a `router` object on `context`.
+It also provides a `router` object on [context](https://facebook.github.io/react/docs/context.html).
 
 #### `context.router`
 
 Contains data and methods relevant to routing. Most useful for imperatively transitioning around the application.
+
+To use it, you must signal to React that you need it by declaring your use of it in your component:
+
+```js
+var MyComponent = React.createClass({
+  contextTypes: {
+    router: React.PropTypes.func.isRequired
+  },
+  render: function() {
+    // here, you can use `this.context.router`
+  }
+});
+
+```
+
+Using `context.router` i.c.w ES6 classes requires a different pattern (note the use of the `static` keyword):
+
+```js
+class MyComponent extends React.Component {
+  static contextTypes = {
+    router: React.PropTypes.func.isRequired
+  }
+
+  render: function() {
+    // here, you can use `this.context.router`
+  }
+});
+
+```
+
+Finally, you can use `context.router` with
+[stateless function components](https://facebook.github.io/react/docs/reusable-components.html#stateless-functions):
+
+```js
+function MyComponent(props, context) {
+  // here, you can use `context.router`
+}
+MyComponent.contextTypes = {
+  router: React.PropTypes.func.isRequired
+}
+```
 
 ##### `push(pathOrLoc)`
 Transitions to a new URL, adding a new entry in the browser history.


### PR DESCRIPTION
Explain usage of `context.router` for:
* Components created with `React.createClass`
* Components created with ES classes extending `React.Component`
* Components created as stateless functions