### PR TITLE
wip: Link doesn't render `href` w/out context

### DIFF
--- a/modules/__tests__/Link-test.js
+++ b/modules/__tests__/Link-test.js
@@ -63,6 +63,27 @@ describe('A <Link>', function () {
     })
   })
 
+  it('constructs fallback href _without_ router context', function () {
+    class LinkWrapper extends Component {
+      render() {
+        return (
+          <Link to={{
+            pathname: '/hello/michael',
+            query: { the: 'query' },
+            hash: '#the-hash'
+          }}>
+            Link
+          </Link>
+        )
+      }
+    }
+
+    render(<LinkWrapper />, node, function () {
+      const a = node.querySelector('a')
+      expect(a.getAttribute('href')).toEqual('/hello/michael?the=query#the-hash')
+    })
+  })
+
   // This test needs to be in its own file with beforeEach(resetHash).
   //
   //it('knows how to make its href with HashHistory', function () {


### PR DESCRIPTION
The issue is that rendering a `<Link />` component outside of router context renders an `<a>` tag _without_ a `href` attribute. I had hoped it would be as easy as changing the `<Link />` return statement to:
```js
    return <a href={to.pathname} {...props} onClick={this.handleClick} />
```
but that doesn't account for query params or hashes :cry:. I'm happy to help create a fix, but I didn't want to spend time on something someone else may have nearly finished.