### PR TITLE
isActive array parameter handling

### DIFF
--- a/modules/__tests__/isActive-test.js
+++ b/modules/__tests__/isActive-test.js
@@ -544,9 +544,9 @@ describe('isActive', function () {
     })
   })
 
-  describe('a pathname that matches URL', function () {
-    describe('with query that does match', function () {
-      it('is active', function (done) {
+  describe('a pathname that matches the URL', function () {
+    describe('with a query containing a repeating parameter', function () {
+      it('is active if the values are specified in the same order', function (done) {
         render((
           <Router history={createHistory('/home?foo=bar&foo=bar1&foo=bar2')}>
             <Route path="/" />
@@ -557,6 +557,48 @@ describe('isActive', function () {
             pathname: '/home',
             query: { foo: [ 'bar', 'bar1', 'bar2' ] }
           })).toBe(true)
+          done()
+        })
+      }),
+      it('is active if the values are specified in a different order', function (done) {
+        render((
+          <Router history={createHistory('/home?foo=bar&foo=bar1&foo=bar2')}>
+            <Route path="/" />
+            <Route path="/home" />
+          </Router>
+        ), node, function () {
+          expect(this.router.isActive({
+            pathname: '/home',
+            query: { foo: [ 'bar1', 'bar', 'bar2' ] }
+          })).toBe(true)
+          done()
+        })
+      })
+      it('is active if an expected param is an empty array that is missing from the URL', function (done) {
+        render((
+          <Router history={createHistory('/home?foo=bar&foo=bar1&foo=bar2')}>
+            <Route path="/" />
+            <Route path="/home" />
+          </Router>
+        ), node, function () {
+          expect(this.router.isActive({
+            pathname: '/home',
+            query: { foo: [ 'bar', 'bar1', 'bar2' ], baz: [ ] }
+          })).toBe(true)
+          done()
+        })
+      })
+      it('is inactive if the expected path contains extra values', function (done) {
+        render((
+          <Router history={createHistory('/home?foo=bar&foo=bar1&foo=bar2')}>
+            <Route path="/" />
+            <Route path="/home" />
+          </Router>
+        ), node, function () {
+          expect(this.router.isActive({
+            pathname: '/home',
+            query: { foo: [ 'bar', 'bar1', 'bar2', 'bar3' ] }
+          })).toBe(false)
           done()
         })
       })
@@ -621,6 +663,7 @@ describe('isActive', function () {
       })
     })
   })
+
 
   describe('dynamic routes', function () {
     const routes = {


### PR DESCRIPTION
`isActive` expects array parameters in the location query to have the same ordering as in the expected location descriptor. I _think_ the router automatically orders them alphabetically when you do `this.context.router.push(myLocationDescriptor)`, so this assumption can become annoying as you then have to make sure you sort before calling `isActive`.

Additionally, if one of the parameters in the expected location descriptor is an empty array, isActive returns false if said parameter is absent from the url.

I am happy to fix this, but I want to confirm with you first that this behaviour is desirable (it is in my case :):

- order of values in array shouldn't matter for `isActive`
- empty array params missing from the URL should not affect `isActive`

Thanks for a great product.