### PR TITLE
[DO NOT MERGE] Use lazily-initialized shims for history singletons

### DIFF
--- a/modules/browserHistory.js
+++ b/modules/browserHistory.js
@@ -1,4 +1,5 @@
 import createBrowserHistory from 'history/lib/createBrowserHistory'
-import createRouterHistory from './createRouterHistory'
-export default createRouterHistory(createBrowserHistory)
 
+import createRouterHistory from './createRouterHistory'
+
+export default createRouterHistory(createBrowserHistory)

--- a/modules/createRouterHistory.js
+++ b/modules/createRouterHistory.js
@@ -4,9 +4,43 @@ const canUseDOM = !!(
   typeof window !== 'undefined' && window.document && window.document.createElement
 )
 
+const HISTORY_METHODS = [
+  'listenBefore',
+  'listen',
+  'transitionTo',
+  'push',
+  'replace',
+  'go',
+  'goBack',
+  'goForward',
+  'createKey',
+  'createPath',
+  'createHref',
+  'createLocation'
+]
+
 export default function (createHistory) {
+  if (!canUseDOM) {
+    return undefined
+  }
+
   let history
-  if (canUseDOM)
-    history = useRouterHistory(createHistory)()
-  return history
+
+  function ensureHistory() {
+    if (!history) {
+      history = useRouterHistory(createHistory)()
+    }
+
+    return history
+  }
+
+  const shim = {
+    __v2_compatible__: true
+  }
+
+  HISTORY_METHODS.forEach(method => {
+    shim[method] = (...args) => ensureHistory()[method](...args)
+  })
+
+  return shim
 }

--- a/modules/hashHistory.js
+++ b/modules/hashHistory.js
@@ -1,4 +1,5 @@
 import createHashHistory from 'history/lib/createHashHistory'
-import createRouterHistory from './createRouterHistory'
-export default createRouterHistory(createHashHistory)
 
+import createRouterHistory from './createRouterHistory'
+
+export default createRouterHistory(createHashHistory)


### PR DESCRIPTION
Maybe?

It'd address e.g. https://github.com/reactjs/react-router/issues/3387.

Going to make a separate PR to history that makes the base href check lazy, which is probably more correct.