### PR TITLE
Add example to `Changes to `this.context`

### DIFF
--- a/upgrade-guides/v2.0.0.md
+++ b/upgrade-guides/v2.0.0.md
@@ -105,6 +105,32 @@ const appHistory = useScroll(useRouterHistory(createBrowserHistory))();
 **NOTE: v2.4.0 and higher include a higher-order component `withRouter` that is now the (highly) recommended way of accessing the `router` object.** Read [the v2.4.0 upgrade guide](/upgrade-guides/v2.4.0.md) for more details.
 
 Only an object named `router` is added to context. Accessing `this.context.history`, `this.context.location`, and `this.context.route` are all deprecated. This new object contains the methods available from `history` (such as `push`, `replace`) along with `setRouteLeaveHook` and `isActive`.
+For instance, if we want to get the `router` object in the component `App`, we should add `router` to contextTypes:
+
+```js
+const App = React.createClass({
+  contextTypes: {
+    color: React.PropTypes.string
+  },
+  render: function() {
+    return (
+      <div>App</div>
+    );
+  }
+});
+```
+Or if you prefer es6 classes:
+
+```js
+class App extends React.Component {
+  // some methods
+}
+
+App.contextTypes = {
+  router: React.PropTypes.object
+}
+```
+Then we can get `router` from `this.context`, and utilize the provide method.
 
 ### Accessing location
 


### PR DESCRIPTION
I think a example will more clearly demonstrate how it works.
They don't need to check in issue or google where can they retrieve the `router` object.
As my opinion, a naive example means a lot to the developers.