### PR TITLE
Make `match` set the location as history entry when creating new memory history object

### DIFF
--- a/modules/match.js
+++ b/modules/match.js
@@ -20,7 +20,7 @@ function match({ history, routes, location, ...options }, callback) {
     'match needs a history or a location'
   )
 
-  history = history || createMemoryHistory({ entrires: [location], ...options })
+  history = history || createMemoryHistory({ entrires: [ location ], ...options })
   const transitionManager = createTransitionManager(
     history,
     createRoutes(routes)

--- a/modules/match.js
+++ b/modules/match.js
@@ -20,7 +20,7 @@ function match({ history, routes, location, ...options }, callback) {
     'match needs a history or a location'
   )
 
-  history = history || createMemoryHistory({ entrires: [ location ], ...options })
+  history = history || createMemoryHistory({ entries: [ location ], ...options })
   const transitionManager = createTransitionManager(
     history,
     createRoutes(routes)

--- a/modules/match.js
+++ b/modules/match.js
@@ -20,7 +20,7 @@ function match({ history, routes, location, ...options }, callback) {
     'match needs a history or a location'
   )
 
-  history = history ? history : createMemoryHistory(options)
+  history = history || createMemoryHistory({ entrires: [location], ...options })
   const transitionManager = createTransitionManager(
     history,
     createRoutes(routes)


### PR DESCRIPTION
I believe, this is a proper fix for https://github.com/denvned/isomorphic-relay-router/issues/26.