### PR TITLE
Add "target" as an optional prop to Link module

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -59,7 +59,8 @@ const Link = React.createClass({
     activeStyle: object,
     activeClassName: string,
     onlyActiveOnIndex: bool.isRequired,
-    onClick: func
+    onClick: func,
+    target: string
   },
 
   getDefaultProps() {


### PR DESCRIPTION
When checking to see if target was supported on the Link module, I first checked props and noticed it wasn't there, but then noticed it was used below in the code. This might help other developers quickly determine that target is a supported prop. 