### PR TITLE
Basename + IndexRedirect not working well together

### DIFF
--- a/modules/__tests__/IndexRedirect-test.js
+++ b/modules/__tests__/IndexRedirect-test.js
@@ -2,6 +2,8 @@ import expect from 'expect'
 import React from 'react'
 import { render, unmountComponentAtNode } from 'react-dom'
 import createHistory from '../createMemoryHistory'
+import useRouterHistory from '../useRouterHistory'
+
 import IndexRedirect from '../IndexRedirect'
 import Router from '../Router'
 import Route from '../Route'
@@ -26,6 +28,25 @@ describe('An <IndexRedirect>', function () {
         </Route>
       </Router>
     ), node, function () {
+      expect(this.state.location.pathname).toEqual('/messages')
+      done()
+    })
+  })
+
+  it('should work with basename', function (done) {
+    const history = useRouterHistory(createHistory)({
+      entries: '/',
+      basename: '/foo'
+    })
+    render((
+      <Router history={history}>
+        <Route path="/">
+          <IndexRedirect to="messages" />
+          <Route path="/messages" />
+        </Route>
+      </Router>
+    ), node, function () {
+      expect(this.state.location.basename).toEqual('/foo')
       expect(this.state.location.pathname).toEqual('/messages')
       done()
     })


### PR DESCRIPTION
Hello,

We use react-router in multiple React applications - thanks a lot for all the hard work -, all using both `basename` and `IndexRedirect` features. We've noticed some strange behavior when using the two, so I began playing with the tests and found the following, which seems odd to me, though I may be missing something.

## Version
2.4.0, possibly others as well

## Test Case
See failing test case commit

## Steps to reproduce

- Setup a `UserRouterHistory` with a basename,
- Setup an `IndexRedirect` to a given pathname
- Match the `IndexRedirect`

## Expected Behavior

- Pathname is updated accordingly and does not include the basename

## Actual Behavior

- Pathname is updated but does include the basename