### PR TITLE
Add version caveats for scroll-behavior docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -117,15 +117,15 @@ A [location descriptor](https://github.com/mjackson/history/blob/master/docs/Glo
   * `hash`: A hash to put in the URL, e.g. `#a-hash`.
   * `state`: State to persist to the `location`.
 
-##### `query` **([Deprecated](https://github.com/reactjs/react-router/blob/master/upgrade-guides/v2.0.0.md#link-to-onenter-and-isactive-use-location-descriptors) see `to`)**
+##### `query` **([Deprecated](/upgrade-guides/v2.0.0.md#link-to-onenter-and-isactive-use-location-descriptors) see `to`)**
 An object of key:value pairs to be stringified.
 
-##### `hash` **([Deprecated](https://github.com/reactjs/react-router/blob/master/upgrade-guides/v2.0.0.md#link-to-onenter-and-isactive-use-location-descriptors) see `to`)**
+##### `hash` **([Deprecated](/upgrade-guides/v2.0.0.md#link-to-onenter-and-isactive-use-location-descriptors) see `to`)**
 A hash to put in the URL, e.g. `#a-hash`.
 
-_Note: React Router currently does not manage scroll position, and will not scroll to the element corresponding to the hash. Scroll position management utilities are available in the [scroll-behavior](https://github.com/taion/scroll-behavior) library._
+_Note: React Router currently does not manage scroll position, and will not scroll to the element corresponding to the hash._
 
-##### `state` **([Deprecated](https://github.com/reactjs/react-router/blob/master/upgrade-guides/v2.0.0.md#link-to-onenter-and-isactive-use-location-descriptors) see `to`)**
+##### `state` **([Deprecated](/upgrade-guides/v2.0.0.md#link-to-onenter-and-isactive-use-location-descriptors) see `to`)**
 State to persist to the `location`.
 
 ##### `activeClassName`

--- a/upgrade-guides/v2.0.0.md
+++ b/upgrade-guides/v2.0.0.md
@@ -72,32 +72,33 @@ import { browserHistory } from 'react-router'
 // v1.x
 import createHashHistory from 'history/lib/createHashHistory'
 const history = createHashHistory({ queryKey: false })
-<Router history={history}/>
+<Router history={history} />
 
 // v2.0.0
 import { Router, useRouterHistory } from 'react-router'
 import { createHashHistory } from 'history'
 // useRouterHistory creates a composable higher-order function
 const appHistory = useRouterHistory(createHashHistory)({ queryKey: false })
-<Router history={appHistory}/>
+<Router history={appHistory} />
 ```
 
 ### Using Scroll Behavior
 
 ```js
-// v1.x
+// v1.x, scroll-behavior < v0.5.0
 import createBrowserHistory from 'history/lib/createBrowserHistory'
 import useScroll from 'scroll-behavior/lib/useStandardScroll'
-const history = useScroll(createBrowserHistory)()
-<Router history={history}/>
 
-// v2.0.0
+const history = useScroll(createBrowserHistory)()
+<Router history={history} />
+
+// v2.0.0, scroll-behavior < v0.5.0
 import { Router, useRouterHistory } from 'react-router'
 import createBrowserHistory from 'history/lib/createBrowserHistory';
 import useScroll from 'scroll-behavior/lib/useStandardScroll';
 
 const appHistory = useScroll(useRouterHistory(createBrowserHistory))();
-<Router history={appHistory}/>
+<Router history={appHistory} />
 ```
 
 ## Changes to `this.context`
@@ -234,7 +235,7 @@ const DeepComponent = React.createClass({
     router: React.PropTypes.object.isRequired
   },
   handleSubmit() {
-    this.context.router.push(...)  
+    this.context.router.push(...)
   }
 }
 
@@ -253,10 +254,10 @@ const DeepComponent = React.createClass({
 
 ```js
 // v1.0.x
-<Link to="/foo" query={{ the: 'query' }}/>
+<Link to="/foo" query={{ the: 'query' }} />
 
 // v2.0.0
-<Link to={{ pathname: '/foo', query: { the: 'query' } }}/>
+<Link to={{ pathname: '/foo', query: { the: 'query' } }} />
 
 // Still valid in 2.x
 <Link to="/foo"/>
@@ -304,7 +305,7 @@ const appHistory = createAppHistory({
   stringifyQuery: stringify
 })
 
-<Router history={appHistory}/>
+<Router history={appHistory} />
 ```
 ## Other Changes
 
@@ -323,7 +324,7 @@ You can now pass a `render` prop to `Router` for it to use for rendering. This a
 
 ```js
 // the default is basically this:
-<Router render={props => <RouterContext {...props}/>}/>
+<Router render={props => <RouterContext {...props} />} />
 ```
 
 `RoutingContext` was undocumented and therefore has no backwards compatibility.

--- a/upgrade-guides/v2.4.0.md
+++ b/upgrade-guides/v2.4.0.md
@@ -11,18 +11,16 @@ import React from 'react'
 import { withRouter } from 'react-router'
 
 const Page = React.createClass({
-
   componentDidMount() {
     this.props.router.setRouteLeaveHook(this.props.route, () => {
       if (this.state.unsaved)
         return 'You have unsaved information, are you sure you want to leave this page?'
     })
-  }
+  },
 
   render() {
     return <div>Stuff</div>
   }
-
 })
 
 export default withRouter(Page)


### PR DESCRIPTION
I don't want to anachronistically update the v2.x upgrade guide to reference libraries that didn't exist at the time, but it's worth noting that the API to scroll-behavior has in fact changed.