### PR TITLE
Make <Link> work with static containers

### DIFF
--- a/modules/RouterUtils.js
+++ b/modules/RouterUtils.js
@@ -1,6 +1,7 @@
 export function createRouterObject(history, transitionManager) {
   return {
     ...history,
+    listen: transitionManager.listen,
     setRouteLeaveHook: transitionManager.listenBeforeLeavingRoute,
     isActive: transitionManager.isActive
   }

--- a/modules/__tests__/Link-test.js
+++ b/modules/__tests__/Link-test.js
@@ -314,6 +314,47 @@ describe('A <Link>', function () {
         </Router>
       ), node, execNextStep)
     })
+
+    it('changes active state inside static components', function (done) {
+      class LinkWrapper extends Component {
+        shouldComponentUpdate() {
+          return false
+        }
+
+        render() {
+          return (
+            <div>
+              <Link to="/hello" activeClassName="active">Link</Link>
+              {this.props.children}
+            </div>
+          )
+        }
+      }
+
+      let a
+      const history = createHistory('/goodbye')
+      const steps = [
+        function () {
+          a = node.querySelector('a')
+          expect(a.className).toEqual('')
+          history.push('/hello')
+        },
+        function () {
+          expect(a.className).toEqual('active')
+        }
+      ]
+
+      const execNextStep = execSteps(steps, done)
+
+      render((
+        <Router history={history} onUpdate={execNextStep}>
+          <Route path="/" component={LinkWrapper}>
+            <Route path="goodbye" component={Goodbye} />
+            <Route path="hello" component={Hello} />
+          </Route>
+        </Router>
+      ), node, execNextStep)
+    })
   })
 
   describe('when clicked', function () {


### PR DESCRIPTION
Fixes #470, thereby unbreaking every project that uses React Redux with React Router.

This follows the approach described in https://github.com/reactjs/react-router/pull/3340#discussion_r60169008, but I’m happy for this to go into 3.0 rather than 2.x. I tested this on a few apps, and it works well in my testing. I’m happy to add as many additional unit tests as you like if this is something you are ready to consider to take in. I believe it’s going to take a huge pain point away from using these together, and I’m super excited about the possibility of this shipping.

Technical details as comments inline.