### PR TITLE
Add routerLink HoC

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -4,6 +4,7 @@
   - [`<Router>`](#router)
   - [`<Link>`](#link)
   - [`<IndexLink>`](#indexlink)
+  - [`routerLink`](#routerlinklinkcomponent)
   - [`withRouter`](#withroutercomponent)
   - [`<RouterContext>`](#routercontext)
     - [`context.router`](#contextrouter)
@@ -162,6 +163,16 @@ Given a route like `<Route path="/users/:userId" />`:
 
 ### `<IndexLink>`
 An `<IndexLink>` is like a [`<Link>`](#link), except it is only active when the current route is exactly the linked route. It is equivalent to `<Link>` with the `onlyActiveOnIndex` prop set.
+
+### `routerLink(linkComponent)`
+A HoC (higher-order component) that wraps another component representing a "link".
+It passes the following additional properties to the wrapped component `linkComponent`:
+
+* `linkActive`: a boolean that is `true` if the provided link matches the active route
+* `linkHref`: a string representing the "formatted" link
+* `handleClick`: a function managing the transition
+
+The properties used by the HoC are `to`, `onClick(e)`, `onlyActiveOnIndex`, `target`, `query` (deprecated), `hash` (deprecated), `state` (deprecated) with the same semantic of [`<Link>`](#link).
 
 ### `withRouter(component)`
 A HoC (higher-order component) that wraps another component to provide `this.props.router`. Pass in your component and it will return the wrapped component.

--- a/modules/__tests__/routerLink-test.js
+++ b/modules/__tests__/routerLink-test.js
@@ -1,0 +1,67 @@
+import expect from 'expect'
+import React, { Component } from 'react'
+import { render } from 'react-dom'
+import createHistory from '../createMemoryHistory'
+import Router from '../Router'
+import Route from '../Route'
+import routerLink from '../routerLink'
+
+describe('routerLink', function () {
+
+  class _MyLink extends Component {
+    render() {
+      return (
+        <div
+          data-linkactive={this.props.linkActive}
+          data-linkHref={this.props.linkHref}
+        ></div>)
+    }
+  }
+
+  const MyLink = routerLink(_MyLink)
+
+  let node
+  beforeEach(function () {
+    node = document.createElement('div')
+  })
+
+  it('knows how to make its hrefs', function () {
+    render((
+      <Router history={createHistory('/')}>
+        <Route path="/" component={() => <MyLink to={{
+          pathname: '/hello/michael',
+          query: { the: 'query' },
+          hash: '#the-hash'
+        }} /> } />
+      </Router>
+    ), node, function () {
+      const linkDiv = node.querySelector('div')
+      expect(linkDiv.getAttribute('data-linkHref')).toEqual('/hello/michael?the=query#the-hash')
+    })
+  })
+
+  describe('when the route is "/"', function () {
+    it('a link to "/" should be active', function () {
+      render((
+        <Router history={createHistory('/')}>
+          <Route path="/" component={() => <MyLink to="/" />} />
+        </Router>
+      ), node, function () {
+        const linkDiv = node.querySelector('div')
+        expect(linkDiv.getAttribute('data-linkactive')).toEqual('true')
+      })
+    })
+    it('a link to "/hello" should not be active', function () {
+      render((
+        <Router history={createHistory('/')}>
+          <Route path="/" component={() => <MyLink to="/hello" />} />
+        </Router>
+      ), node, function () {
+        const linkDiv = node.querySelector('div')
+        expect(linkDiv.getAttribute('data-linkactive')).toEqual('false')
+      })
+    })
+  })
+
+
+})

--- a/modules/index.js
+++ b/modules/index.js
@@ -3,6 +3,7 @@ export Router from './Router'
 export Link from './Link'
 export IndexLink from './IndexLink'
 export withRouter from './withRouter'
+export routerLink from './routerLink'
 
 /* components (configuration) */
 export IndexRedirect from './IndexRedirect'

--- a/modules/routerLink.js
+++ b/modules/routerLink.js
@@ -1,0 +1,114 @@
+import React from 'react'
+import warning from './routerWarning'
+
+import hoistStatics from 'hoist-non-react-statics'
+
+import { routerShape } from './PropTypes'
+
+const { bool, object, string, func, oneOfType } = React.PropTypes
+
+function isLeftClickEvent(event) {
+  return event.button === 0
+}
+
+function isModifiedEvent(event) {
+  return !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey)
+}
+
+function createLocationDescriptor(to, { query, hash, state }) {
+  if (query || hash || state) {
+    return { pathname: to, query, hash, state }
+  }
+
+  return to
+}
+
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component'
+}
+
+export default function routerLink(WrappedComponent) {
+  const RouterLink = React.createClass({
+
+    contextTypes: {
+      router: routerShape
+    },
+
+    propTypes: {
+      to: oneOfType([ string, object ]).isRequired,
+      query: object,
+      hash: string,
+      state: object,
+      onlyActiveOnIndex: bool.isRequired,
+      onClick: func,
+      target: string
+    },
+
+    displayName: `routerLink(${getDisplayName(WrappedComponent)})`,
+    WrappedComponent: WrappedComponent,
+
+    getDefaultProps() {
+      return {
+        onlyActiveOnIndex: false
+      }
+    },
+
+    handleClick(event) {
+      let allowTransition = true
+
+      if (this.props.onClick)
+        this.props.onClick(event)
+
+      if (isModifiedEvent(event) || !isLeftClickEvent(event))
+        return
+
+      if (event.defaultPrevented === true)
+        allowTransition = false
+
+      // If target prop is set (e.g. to "_blank") let browser handle link.
+      /* istanbul ignore if: untestable with Karma */
+      if (this.props.target) {
+        if (!allowTransition)
+          event.preventDefault()
+
+        return
+      }
+
+      event.preventDefault()
+
+      if (allowTransition) {
+        const { to, query, hash, state } = this.props
+        const location = createLocationDescriptor(to, { query, hash, state })
+
+        this.context.router.push(location)
+      }
+    },
+
+    render() {
+      const { to, query, hash, state, onlyActiveOnIndex, ...props } = this.props
+      warning(
+        !(query || hash || state),
+        'the `query`, `hash`, and `state` props on `<Link>` are deprecated, use `<Link to={{ pathname, query, hash, state }}/>. http://tiny.cc/router-isActivedeprecated'
+      )
+
+      // Ignore if rendered outside the context of router, simplifies unit testing.
+      const { router } = this.context
+
+      props.location = createLocationDescriptor(to, { query, hash, state })
+      if (router) {
+        props.linkHref = router.createHref(props.location)
+        props.linkActive = router.isActive(props.location, onlyActiveOnIndex)
+      }
+
+      return (
+          <WrappedComponent
+            {...props}
+            handleClick={this.handleClick}
+          />
+      )
+    }
+
+  })
+
+  return hoistStatics(RouterLink, WrappedComponent)
+}


### PR DESCRIPTION
routerLink provides a convenient way to customize the appearance of `<Link>`s by essentially "injecting" some properties to the wrapped component such as linkActive and handleClick.

For example, with this component it is easy (and maintainable) to write components that applies classes if the link is not active or that should not be "fully clickable" (e.g., a `<div>` containing the actual link).

Furthermore, this component extracts most of the logic from `<Link>` which now becomes a presentation-only component wrapped by routerLink (hence more maintainable, hopefully).