### PR TITLE
Implement ContextUtils as mixins

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { routerShape } from './PropTypes'
-import { connectToContext } from './ContextUtils'
+import { ContextSubscriber } from './ContextUtils'
 
 const { bool, object, string, func, oneOfType } = React.PropTypes
 
@@ -40,6 +40,8 @@ function isEmptyObject(object) {
  *   <Link ... query={{ show: true }} state={{ the: 'state' }} />
  */
 const Link = React.createClass({
+
+  mixins: [ ContextSubscriber('router') ],
 
   contextTypes: {
     router: routerShape
@@ -122,4 +124,4 @@ const Link = React.createClass({
 
 })
 
-export default connectToContext(Link, 'router', object)
+export default Link

--- a/modules/RouterContext.js
+++ b/modules/RouterContext.js
@@ -2,17 +2,18 @@ import invariant from 'invariant'
 import React from 'react'
 
 import getRouteParams from './getRouteParams'
-import { createContextProvider } from './ContextUtils'
+import { ContextProvider } from './ContextUtils'
 import { isReactChildren } from './RouteUtils'
 
 const { array, func, object } = React.PropTypes
-const RouterContextProvider = createContextProvider('router', object.isRequired)
 
 /**
  * A <RouterContext> renders the component tree for a given router state
  * and sets the history object and the current location in context.
  */
 const RouterContext = React.createClass({
+
+  mixins: [ ContextProvider('router') ],
 
   propTypes: {
     router: object.isRequired,
@@ -90,21 +91,12 @@ const RouterContext = React.createClass({
       }, element)
     }
 
-    const isEmpty = element === null || element === false
     invariant(
-      isEmpty || React.isValidElement(element),
+      element === null || element === false || React.isValidElement(element),
       'The root route must render a single element'
     )
 
-    if (isEmpty) {
-      return element
-    }
-
-    return (
-      <RouterContextProvider>
-        {element}
-      </RouterContextProvider>
-    )
+    return element
   }
 
 })


### PR DESCRIPTION
As discussed in https://github.com/reactjs/react-router/issues/3439, these are implementation details and are better implemented as mixins so that it’s easier to kill them later. They don’t leak into public API, and React mixin merging behavior comes in handy here.

This way the hierarchy stays flat but we work around https://github.com/facebook/react/issues/2517.