### PR TITLE
Attach current location and params to context.router

### DIFF
--- a/modules/Router.js
+++ b/modules/Router.js
@@ -62,13 +62,7 @@ const Router = React.createClass({
     }
 
     const { history } = this.props
-    const router = createRouterObject(history, this.transitionManager)
-
-    return {
-      ...router,
-      location: state.location,
-      params: state.params
-    }
+    return createRouterObject(history, this.transitionManager, state)
   },
 
   createTransitionManager() {

--- a/modules/Router.js
+++ b/modules/Router.js
@@ -62,6 +62,8 @@ const Router = React.createClass({
       if (error) {
         this.handleError(error)
       } else {
+        router.location = state.location
+        router.params = state.params
         this.setState(state, this.props.onUpdate)
       }
     })
@@ -82,7 +84,10 @@ const Router = React.createClass({
       history,
       createRoutes(routes || children)
     )
+
     const router = createRouterObject(history, transitionManager)
+    router.location = null
+    router.params = null
 
     return { transitionManager, router }
   },

--- a/modules/RouterUtils.js
+++ b/modules/RouterUtils.js
@@ -1,7 +1,9 @@
-export function createRouterObject(history, transitionManager) {
+export function createRouterObject(history, transitionManager, state) {
   return {
     ...history,
     setRouteLeaveHook: transitionManager.listenBeforeLeavingRoute,
-    isActive: transitionManager.isActive
+    isActive: transitionManager.isActive,
+    location: state.location,
+    params: state.params
   }
 }

--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -297,6 +297,12 @@ describe('Router', function () {
       const assertProps = (props) => {
         expect(props.routes).toEqual([ route ])
         expect(props.components).toEqual([ MyComponent ])
+
+        expect(props.params).toEqual({})
+        expect(props.location.pathname).toEqual('/')
+        expect(props.router.params).toEqual({})
+        expect(props.router.location.pathname).toEqual('/')
+
         expect(props.foo).toBe('bar')
         expect(props.render).toNotExist()
         done()

--- a/modules/__tests__/RouterContext-test.js
+++ b/modules/__tests__/RouterContext-test.js
@@ -31,7 +31,7 @@ describe('RouterContext', () => {
       isActive: expect.createSpy().andReturn(isActiveSentinel)
     }
 
-    router = createRouterObject(history, transitionManager)
+    router = createRouterObject(history, transitionManager, {})
 
     class Component extends React.Component {
       constructor(props, ctx) {

--- a/modules/__tests__/serverRendering-test.js
+++ b/modules/__tests__/serverRendering-test.js
@@ -152,6 +152,17 @@ describe('server rendering', function () {
     })
   })
 
+  it('includes params and location in the props', function (done) {
+    match({ routes, location: '/dashboard' }, function (error, redirectLocation, renderProps) {
+      expect(renderProps.params).toEqual({})
+      expect(renderProps.router.params).toEqual({})
+
+      expect(renderProps.location.pathname).toEqual('/dashboard')
+      expect(renderProps.router.location.pathname).toEqual('/dashboard')
+      done()
+    })
+  })
+
   it('accepts a basename option', function (done) {
     match({ routes, location: '/dashboard', basename: '/nasebame' }, function (error, redirectLocation, renderProps) {
       const string = renderToString(

--- a/modules/match.js
+++ b/modules/match.js
@@ -39,18 +39,24 @@ function match({ history, routes, location, ...options }, callback) {
     })
   }
 
-  const router = createRouterObject(history, transitionManager)
-
   transitionManager.match(location, function (error, redirectLocation, nextState) {
-    callback(
-      error,
-      redirectLocation,
-      nextState && {
+    let renderProps
+
+    if (nextState) {
+      const router = {
+        ...createRouterObject(history, transitionManager),
+        location: nextState.location,
+        params: nextState.params
+      }
+
+      renderProps = {
         ...nextState,
         router,
         matchContext: { transitionManager, router }
       }
-    )
+    }
+
+    callback(error, redirectLocation, renderProps)
 
     // Defer removing the listener to here to prevent DOM histories from having
     // to unwind DOM event listeners unnecessarily, in case callback renders a

--- a/modules/match.js
+++ b/modules/match.js
@@ -43,12 +43,7 @@ function match({ history, routes, location, ...options }, callback) {
     let renderProps
 
     if (nextState) {
-      const router = {
-        ...createRouterObject(history, transitionManager),
-        location: nextState.location,
-        params: nextState.params
-      }
-
+      const router = createRouterObject(history, transitionManager, nextState)
       renderProps = {
         ...nextState,
         router,


### PR DESCRIPTION
Not sure if this is a great way to do it but let’s start here. Partially fixes #3325—at least for my use cases.

I’m not sure how to put `route` there because it depends on how deep you are. So I just limited it to `params` and `location`.