### PR TITLE
Don't crash on invalid uri query parameters.

### DIFF
--- a/modules/PatternUtils.js
+++ b/modules/PatternUtils.js
@@ -4,6 +4,15 @@ function escapeRegExp(string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
+function _tryDecodeURIComponent(value) {
+  try {
+    return decodeURIComponent(value)
+  } catch(e) {
+    // Ignore 'URI malformed' error.
+    return null
+  }
+}
+
 function _compilePattern(pattern) {
   let regexpSource = ''
   const paramNames = []
@@ -116,7 +125,7 @@ export function matchPattern(pattern, pathname) {
   return {
     remainingPathname,
     paramNames,
-    paramValues: match.slice(1).map(v => v && decodeURIComponent(v))
+    paramValues: match.slice(1).map(v => v && _tryDecodeURIComponent(v))
   }
 }
 

--- a/modules/PatternUtils.js
+++ b/modules/PatternUtils.js
@@ -4,15 +4,6 @@ function escapeRegExp(string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
-function _tryDecodeURIComponent(value) {
-  try {
-    return decodeURIComponent(value)
-  } catch(e) {
-    // Ignore 'URI malformed' error.
-    return null
-  }
-}
-
 function _compilePattern(pattern) {
   let regexpSource = ''
   const paramNames = []
@@ -80,6 +71,7 @@ export function compilePattern(pattern) {
  * - **             Consumes (greedy) all characters up to the next character
  *                  in the pattern, or to the end of the URL if there is none
  *
+ *  The function calls callback(error, matched) when finished.
  * The return value is an object with the following properties:
  *
  * - remainingPathname
@@ -125,7 +117,7 @@ export function matchPattern(pattern, pathname) {
   return {
     remainingPathname,
     paramNames,
-    paramValues: match.slice(1).map(v => v && _tryDecodeURIComponent(v))
+    paramValues: match.slice(1).map(v => v && decodeURIComponent(v))
   }
 }
 

--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -276,6 +276,26 @@ describe('Router', function () {
       })
     })
 
+    it('handles error that are not valid URI character', function (done) {
+      let uriMalformedError
+      const errorSpy = expect.createSpy()
+
+      try {
+        decodeURIComponent('%') // throw URIError
+      } catch (error) {
+        uriMalformedError = error
+      }
+
+      render((
+        <Router history={createHistory('/%')} onError={errorSpy}>
+          <Route path="*" />
+        </Router>
+      ), node, function () {
+        expect(errorSpy).toHaveBeenCalledWith(uriMalformedError)
+        done()
+      })
+    })
+
   })
 
   describe('render prop', function () {

--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -277,21 +277,14 @@ describe('Router', function () {
     })
 
     it('handles error that are not valid URI character', function (done) {
-      let uriMalformedError
       const errorSpy = expect.createSpy()
-
-      try {
-        decodeURIComponent('%') // throw URIError
-      } catch (error) {
-        uriMalformedError = error
-      }
 
       render((
         <Router history={createHistory('/%')} onError={errorSpy}>
           <Route path="*" />
         </Router>
       ), node, function () {
-        expect(errorSpy).toHaveBeenCalledWith(uriMalformedError)
+        expect(errorSpy).toHaveBeenCalled()
         done()
       })
     })

--- a/modules/__tests__/getParams-test.js
+++ b/modules/__tests__/getParams-test.js
@@ -114,14 +114,6 @@ describe('getParams', function () {
     })
   })
 
-  describe('when the path contains invalid URI character', function () {
-    const pattern = '/foo/:invalid'
-
-    it('should ignore error that are not valid URI character', function () {
-      expect(getParams(pattern, '/foo/%')).toEqual({ invalid: null })
-    })
-  })
-
   describe('when a pattern has a *', function () {
     describe('and the path matches', function () {
       it('returns an object with the params', function () {

--- a/modules/__tests__/getParams-test.js
+++ b/modules/__tests__/getParams-test.js
@@ -114,6 +114,14 @@ describe('getParams', function () {
     })
   })
 
+  describe('when the path contains invalid URI character', function () {
+    const pattern = '/foo/:invalid'
+
+    it('should ignore error that are not valid URI character', function () {
+      expect(getParams(pattern, '/foo/%')).toEqual({ invalid: null })
+    })
+  })
+
   describe('when a pattern has a *', function () {
     describe('and the path matches', function () {
       it('returns an object with the params', function () {

--- a/modules/matchRoutes.js
+++ b/modules/matchRoutes.js
@@ -88,13 +88,17 @@ function matchRouteDeep(
   // Only try to match the path if the route actually has a pattern, and if
   // we're not just searching for potential nested absolute paths.
   if (remainingPathname !== null && pattern) {
-    const matched = matchPattern(pattern, remainingPathname)
-    if (matched) {
-      remainingPathname = matched.remainingPathname
-      paramNames = [ ...paramNames, ...matched.paramNames ]
-      paramValues = [ ...paramValues, ...matched.paramValues ]
-    } else {
-      remainingPathname = null
+    try {
+      const matched = matchPattern(pattern, remainingPathname)
+      if (matched) {
+        remainingPathname = matched.remainingPathname
+        paramNames = [ ...paramNames, ...matched.paramNames ]
+        paramValues = [ ...paramValues, ...matched.paramValues ]
+      } else {
+        remainingPathname = null
+      }
+    } catch (error) {
+      callback(error)
     }
 
     // By assumption, pattern is non-empty here, which is the prerequisite for


### PR DESCRIPTION
Replace decodeURIComponent with _tryDecodeURIComponent to ignore crash "URIError: malformed URI sequence".
