### PR TITLE
Support async behavior in setRouteLeaveHook

### DIFF
--- a/docs/guides/ConfirmingNavigation.md
+++ b/docs/guides/ConfirmingNavigation.md
@@ -1,6 +1,9 @@
 # Confirming Navigation
 
-You can prevent a transition from happening or prompt the user before leaving a [route](/docs/Glossary.md#route) with a leave hook.
+You can prevent a transition from happening or prompt the user before leaving a
+[route](/docs/Glossary.md#route) with a leave hook. Leave hooks can be
+asynchronous if you accept the second `callback` parameter, except in the case
+of beforeUnload hooks which must always be synchronous.
 
 ```js
 const Home = withRouter(
@@ -10,11 +13,15 @@ const Home = withRouter(
       this.props.router.setRouteLeaveHook(this.props.route, this.routerWillLeave)
     },
 
-    routerWillLeave(nextLocation) {
-      // return false to prevent a transition w/o prompting the user,
-      // or return a string to allow the user to decide:
-      if (!this.state.isSaved)
-        return 'Your work is not saved! Are you sure you want to leave?'
+    routerWillLeave(nextLocation, callback) {
+      if (callback !== undefined) {
+        doSomethingAsync().then(callback)
+      } else {  // This is the beforeUnload case.
+        // Return false to prevent a transition w/o prompting the user,
+        // or return a string to allow the user to decide:
+        if (!this.state.isSaved)
+          return 'Your work is not saved! Are you sure you want to leave?'
+      }
     },
 
     // ...

--- a/modules/createTransitionManager.js
+++ b/modules/createTransitionManager.js
@@ -1,5 +1,7 @@
 import warning from './routerWarning'
 import { REPLACE } from 'history/lib/Actions'
+import { loopAsync } from 'history/lib/AsyncUtils'
+import runTransitionHook from 'history/lib/runTransitionHook'
 import computeChangedRoutes from './computeChangedRoutes'
 import { runEnterHooks, runChangeHooks, runLeaveHooks } from './TransitionUtils'
 import { default as _isActive } from './isActive'
@@ -141,14 +143,17 @@ export default function createTransitionManager(history, routes) {
         computeChangedRoutes(state, partialNextState).leaveRoutes
       )
 
-      let result
-      for (let i = 0, len = hooks.length; result == null && i < len; ++i) {
-        // Passing the location arg here indicates to
-        // the user that this is a transition hook.
-        result = hooks[i](location)
-      }
-
-      callback(result)
+      // Call the hook, passing in a callback so that it can be used for
+      // asynchronous transition confirmation if desired.
+      loopAsync(
+        hooks.length,
+        (index, next, done) => {
+          runTransitionHook(hooks[index], location, (result) => {
+            result != null ? done(result) : next()
+          })
+        },
+        callback
+      )
     })
   }
 


### PR DESCRIPTION
The underlying history library supports asynchronous transition hooks, but this
behavior was previously not exposed in react-router. This changeset exposes the
callback parameter to transition hooks, which can be used to perform
asynchronous transition confirmations.

Just like the `nextLocation` parameter, the `callback` parameter is not provided for
the beforeUnload hooks.

If there are multiple transition hooks, the first one to call the callback
function with a non-null value will be used. This behavior is only temporary
until `listenBeforeLeavingRoute` is updated to only support a single hook per
route.

/cc @taion @mjackson 