### PR TITLE
Enable Multiple Routes to same component

### DIFF
--- a/modules/PatternUtils.js
+++ b/modules/PatternUtils.js
@@ -78,6 +78,13 @@ export function compilePattern(pattern) {
  * - paramValues
  */
 export function matchPattern(pattern, pathname) {
+  // Check if pattern has pipes separating the paths
+  if (/\|/.test(pattern)) {
+    let match = pathname.match(new RegExp(`^/?(${pattern})$`), 'i')
+    if (match != null)
+      pattern = match[0]
+  }
+  
   // Ensure pattern starts with leading slash for consistency with pathname.
   if (pattern.charAt(0) !== '/') {
     pattern = `/${pattern}`

--- a/modules/PatternUtils.js
+++ b/modules/PatternUtils.js
@@ -81,7 +81,7 @@ export function matchPattern(pattern, pathname) {
   // Check if pattern has pipes separating the paths
   if (/\|/.test(pattern)) {
     let pipedPath = pattern.match(/[a-zA-Z0-9_-]+\|[a-zA-Z0-9_-]+((\|[a-zA-Z0-9_-]*)*)?/)
-    if (pipedPath != null){
+    if (pipedPath != null) {
       pipedPath = pipedPath[0]
     }
 
@@ -97,7 +97,6 @@ export function matchPattern(pattern, pathname) {
   }
 
   let { regexpSource, paramNames, tokens } = compilePattern(pattern)
-
   if (pattern.charAt(pattern.length - 1) !== '/') {
     regexpSource += '/?' // Allow optional path separator at end.
   }

--- a/modules/PatternUtils.js
+++ b/modules/PatternUtils.js
@@ -80,15 +80,22 @@ export function compilePattern(pattern) {
 export function matchPattern(pattern, pathname) {
   // Check if pattern has pipes separating the paths
   if (/\|/.test(pattern)) {
-    let match = pathname.match(new RegExp(`^/?(${pattern})$`), 'i')
-    if (match != null)
-      pattern = match[0]
+    let pipedPath = pattern.match(/[a-zA-Z0-9_-]+\|[a-zA-Z0-9_-]+((\|[a-zA-Z0-9_-]*)*)?/)
+    if (pipedPath != null){
+      pipedPath = pipedPath[0]
+    }
+
+    let match = pathname.match(`(${pipedPath})`)
+    if (match != null) {
+      pattern = pattern.replace(pipedPath, match[0])
+    }
   }
-  
+
   // Ensure pattern starts with leading slash for consistency with pathname.
   if (pattern.charAt(0) !== '/') {
     pattern = `/${pattern}`
   }
+
   let { regexpSource, paramNames, tokens } = compilePattern(pattern)
 
   if (pattern.charAt(pattern.length - 1) !== '/') {

--- a/modules/__tests__/matchPattern-test.js
+++ b/modules/__tests__/matchPattern-test.js
@@ -40,5 +40,10 @@ describe('matchPattern', function () {
   it('works with greedy and non-greedy splat', function () {
     assertMatch('/**/*.jpg', '/files/path/to/file.jpg', '', [ 'splat', 'splat' ], [ 'files/path/to', 'file' ])
   })
+  
+  it('works with pipes', function () {
+    assertMatch('/one|two', '/one', '', [], [])
+    assertMatch('/one|two', '/two', '', [], [])
+  })
 
 })

--- a/modules/__tests__/matchPattern-test.js
+++ b/modules/__tests__/matchPattern-test.js
@@ -44,6 +44,12 @@ describe('matchPattern', function () {
   it('works with pipes', function () {
     assertMatch('/one|two', '/one', '', [], [])
     assertMatch('/one|two', '/two', '', [], [])
+    assertMatch('/one|two/:id', '/one/path/', '', [ 'id' ], [ 'path' ])
+    assertMatch('/one|two/:id', '/two/path/', '', [ 'id' ], [ 'path' ])
+    assertMatch('/one|two/*.*', '/one/path.jpg', '', [ 'splat', 'splat' ], [ 'path', 'jpg' ])
+    assertMatch('/one|two/*.*', '/two/path.jpg', '', [ 'splat', 'splat' ], [ 'path', 'jpg' ])
+    assertMatch('/one|two/**/*.jpg', '/one/files/path/to/file.jpg', '', [ 'splat', 'splat' ], [ 'files/path/to', 'file' ])
+    assertMatch('/one|two/**/*.jpg', '/two/files/path/to/file.jpg', '', [ 'splat', 'splat' ], [ 'files/path/to', 'file' ])
   })
 
 })


### PR DESCRIPTION
Here at work we needed to use some different pathnames and render the same component. The solution repeating <Route>s to was a little hard to maintain and understand the routes. Thinking in this, I developed a solution to render the same component using different paths separated by pipes.

Instead of using:
```javascript
    <Route path="/" component={App}>
      <IndexRoute component={Index}/>
      <Route path = "myaccount" component={Account} />
      <Route path = "my-account" component={Account} />
      <Route path = "account" component={Account} />
    </Route>
```
Now we candeclare just one component:
```javascript
    <Route path="/" component={App}>
      <IndexRoute component={Index}/>
      <Route path = "myaccount|my-account|account" component={Account} />
    </Route>
```

All tests has passed and I wrote some more to test if everything was working fine