### PR TITLE
Attempting to make `props.params` a well-behaved immutable

### DIFF
--- a/modules/__tests__/_bc-Router-test.js
+++ b/modules/__tests__/_bc-Router-test.js
@@ -171,6 +171,42 @@ describe('v1 Router', function () {
     })
   })
 
+  describe.only('passed params', function () {
+    it('should be immutable', function (done) {
+      const history = createHistory('/point/a')
+      let lastParams
+      let currentParams
+      class MyComponent extends Component {
+        render() {
+          lastParams = currentParams
+          currentParams = this.props.params
+          return <div>{this.props.params.someToken}</div>
+        }
+      }
+
+      render((
+        <Router history={history}>
+          <Route path="point/:someToken" component={MyComponent} />
+        </Router>
+      ), node, function () {
+        expect(node.textContent).toBe('a')
+        expect(lastParams).toBe(undefined)
+        expect(lastParams).toNotBe(currentParams)
+
+        history.pushState(null, '/point/a')
+        expect(lastParams).toBe(currentParams)
+
+        history.pushState(null, '/point/b')
+        expect(lastParams).toNotBe(currentParams)
+
+        history.pushState(null, '/point/b')
+        expect(lastParams).toBe(currentParams)
+
+        done()
+      })
+    })
+  })
+
   describe('at a route with special characters', function () {
     it('does not double escape', function (done) {
       // https://github.com/reactjs/react-router/issues/1574


### PR DESCRIPTION
### Issue I'm trying to solve

While trying to write helpers for redux-observable to make using redux and rxjs more ergonomic with react-router, I ran into a need to be able to know if anything under `props.params` has actually changed. At that point I discovered that `props.params` is always a new instance, even if the properties underneath it have not changed.

Ideally, we'd be able to check `nextProps.params === currentProps.params` in our components to know if we should update or fire other logic.

Right now props.params is at least not being mutated, but that's more because it's stateless so it's brand new every time.

### What I've attempted here isn't working yet.

1. I'm not entirely sure how to get the test harness to act like route params have changed. So the test I've added is likely garbage.
2. Basically I tried to move `getRouteParams` to be a method of `RouteContext`, so RouteContext could track the current route params so they can be compared after they change. I then made an attempt at making them route params immutable.

### It's a start

Unfortunately, I don't have much more time today to dig into this because I have other deliverables and I'll just need to work around our issue with react-router and circle back

I'd love any advice/help in getting this to work, particularly in the tests. I'm pretty new to hacking on react router, as we were running a fork of react-router for a while that @jayphelps maintained for us.