### PR TITLE
Add router to props for route components

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -485,6 +485,9 @@ The dynamic segments of the URL.
 #### `route`
 The route that rendered this component.
 
+#### `router`
+Contains methods relevant to routing. Most useful for imperatively transitioning around the application.
+
 #### `routeParams`
 A subset of `this.props.params` that were directly specified in this component's route. For example, if the route's path is `users/:userId` and the URL is `/users/123/portfolios/345` then `this.props.routeParams` will be `{userId: '123'}`, and `this.props.params` will be `{userId: '123', portfolioId: 345}`.
 

--- a/modules/RouterContext.js
+++ b/modules/RouterContext.js
@@ -44,7 +44,7 @@ const RouterContext = React.createClass({
   },
 
   render() {
-    const { location, routes, params, components } = this.props
+    const { location, routes, params, components, router } = this.props
     let element = null
 
     if (components) {
@@ -58,6 +58,7 @@ const RouterContext = React.createClass({
           location,
           params,
           route,
+          router,
           routeParams,
           routes
         }

--- a/modules/__tests__/RouterContext-test.js
+++ b/modules/__tests__/RouterContext-test.js
@@ -67,6 +67,19 @@ describe('RouterContext', () => {
       done()
     })
   })
+  
+  it('injects a `router` object into props of route components', (done) => {
+    class RoutedComponent extends React.Component {
+      render() {
+        expect(this.props.router).toBeA(Object)
+        return null
+      }
+    }
+
+    match({ location: '/', routes: { path: '/', component: RoutedComponent } }, (err, redirect, renderProps) => {
+      render(<RouterContext {...renderProps} history={history} router={router}  />, node, done)
+    })
+  })
 
   describe('some weird tests that test implementation and should probably go away', () => {
     it('proxies calls to `push` to `props.history`', (done) => {


### PR DESCRIPTION
Per discussion in #3325. It's a bit awkward to have to opt in to context or wrap route components in `withRouter` in order to do things like `router.push` considering all the other routing concerns already injected into route components.

If this can go in 2.x I can retarget there. I think the issue title threw me :confused: