### PR TITLE
Fix setRouteLeaveHook references in docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -201,6 +201,18 @@ Go back one entry in the history.
 ##### `goForward()`
 Go forward one entry in the history.
 
+##### `setRouteLeaveHook(route, hook)`
+Registers the given hook function to run before leaving the given route.
+
+During a normal transition, the hook function receives the next location as its only argument and can return either a prompt message (string) to show the user, to make sure they want to leave the page; or `false`, to prevent the transition. Any other return value will have no effect.
+
+During the beforeunload event (in browsers) the hook receives no arguments.
+In this case it must return a prompt message to prevent the transition.
+
+Returns a function that may be used to unbind the listener.
+
+You don't need to manually tear down the route leave hook in most cases. We automatically remove all attached route leave hooks after leaving the associated route.
+
 ##### `createPath(pathOrLoc, query)`
 Stringifies the query into the pathname, using the router's config.
 

--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -244,7 +244,7 @@ type Router = {
   go(n: number) => void;
   goBack() => void;
   goForward() => void;
-  setRouteLeaveHook(hook: RouteHook) => Function;
+  setRouteLeaveHook(route: Route, hook: RouteHook) => Function;
   isActive(location: LocationDescriptor, indexOnly: boolean) => void;
 };
 ```

--- a/modules/createTransitionManager.js
+++ b/modules/createTransitionManager.js
@@ -198,9 +198,9 @@ export default function createTransitionManager(history, routes) {
    * Registers the given hook function to run before leaving the given route.
    *
    * During a normal transition, the hook function receives the next location
-   * as its only argument and must return either a) a prompt message to show
-   * the user, to make sure they want to leave the page or b) false, to prevent
-   * the transition.
+   * as its only argument and can return either a prompt message (string) to show the user,
+   * to make sure they want to leave the page; or `false`, to prevent the transition.
+   * Any other return value will have no effect.
    *
    * During the beforeunload event (in browsers) the hook receives no arguments.
    * In this case it must return a prompt message to prevent the transition.


### PR DESCRIPTION
Basically the text for API docs is copied from `createTransitionManager`, looks like it is good, though didn't had chance to dig into router's internals.
Removed last line _Returns a function that may be used to unbind the listener._, as react-router manages this itself.

Let me know what you think. Hope got it right.

Fixes #3488 