### PR TITLE
Enhancing the onClick event object

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -70,7 +70,11 @@ const Link = React.createClass({
     let allowTransition = true
 
     if (this.props.onClick)
-      this.props.onClick(event)
+      this.props.onClick(Object.assign({},
+        event,
+        {linkProps: this.props},
+        this.context
+      ))
 
     if (isModifiedEvent(event) || !isLeftClickEvent(event))
       return
@@ -92,7 +96,7 @@ const Link = React.createClass({
     if (allowTransition) {
       const { to } = this.props
 
-      this.context.router.push(to)
+      this.context.router.push(event.linkProps.redirectTo || to)
     }
   },
 


### PR DESCRIPTION
It would be good to enhance the synthetic event passed to the `onClick` event handler with extra information from the `Link` component itself and the router.   Since no one should be interested in the instance of Link itself, I propose passing just its properties as the `linkProps` property of the event object.  The router instance is available from `this.context` that can be merged straight away.  If, at any time and as requested elsewhere, `location` also becomes available in the context, it would also become available in the event object.  This would allow for more informed decisions in the `onClick` handler such as:  

```js
<Link to="somewhere" onClick={ev => {
  if (ev.router.isActive(ev.linkProps.to)) ev.preventDefault();
}}>
```

With this information, it would be easy for anyone to implement relative links just by composing the values in `ev.location.pathname`, `ev.linkProps.to` 

Though calling `ev.router.push` would be the natural way to redirect such a relative link, I would suggest accepting a `ev.linkProps.redirectTo` property.  This property is initially `undefined` but can be set by the developer in the `onClick` handler.   Then, it would be used in `this.context.router.push(event.linkProps.redirectTo || to)`.  The advantage of doing this so is that it goes through the normal flow of code, checking for left-click and modifier keys.

I think the changes are inexpensive (requires no extra resources) and backward compatible with existing code and provides tons of useful information that may help developers take better decisions in the event handler.