### PR TITLE
Browserify production build is not optimized by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "history": "^2.0.1",
     "hoist-non-react-statics": "^1.0.5",
     "invariant": "^2.2.1",
-    "warning": "^2.1.0"
+    "warning": "^2.1.0",
+    "loose-envify": "^1.2.0"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0"
@@ -85,6 +86,11 @@
     "style-loader": "^0.13.1",
     "webpack": "^1.12.14",
     "webpack-dev-middleware": "^1.6.1"
+  },
+  "browserify": {
+    "transform": [
+      "loose-envify"
+    ]
   },
   "tags": [
     "react",


### PR DESCRIPTION
Hey hey,

_(formal bug report below, without as much context on my solution)_

> TL;DR; Like `react`, use `loose-envify` dependency / browserify transform to prevent browserify users from shipping development code in production.
> (Warning: big file) L248 of https://github.com/ThibWeb/react-router-browserify-build/blob/master/bundle.js#L248.

When using `browserify` to bundle a project that uses `react-router`, the default configuration of browserify transforms causes around 3kb of minified/gzipped warning messages to end up in the production bundles.

The source of the problem is that by default browserify transforms do not run on packages in `node_modules`. Configuring those to run on the whole bundle is simple, but I believe [this is counter-intuitive to the common "best practices](https://github.com/babel/babelify#why-arent-files-in-node_modules-being-transformed)", and people might overlook this.

I imagine this hasn't been reported before because React users seem to use Webpack more than Browserify, and Webpack's `DefinePlugin` targets the whole bundle.

`facebook/react` handles this problem by depending on `loose-envify`, and [declaring the transform it in its `package.json`](https://github.com/facebook/react/blob/c9504d99a55d544b38ad452a776250e3ea6ee68c/packages/react/package.json#L30). Since React itself does this I believe that react-router should follow the lead and _not rely on users to do the right thing_. That said, it's another burden on the package authors for something that can also be handled with appropriate configuration by users. It also needs to be done in https://github.com/mjackson/history, and a big number of other React-related projects I imagine.

The other option is to document this issue in this project and others, by specifying the consequences (dev code in production, dead weight in the JS bundles) and fix (`global` flag for a transform that replaces `NODE_ENV` and potentially other variables).

---- 

## Version
2.3.0, 2.4.1, and `history@2.1.2` (probably all of `react-router@2` & other versions of `history` as well)

## Test Case

https://github.com/ThibWeb/react-router-browserify-build
(Warning: big file) L248 of https://github.com/ThibWeb/react-router-browserify-build/blob/master/bundle.js#L248.

## Steps to reproduce

Compile a project using `react-router` with browserify, without running an "envify" transform over all `node_modules` (default behavior).

Example: `NODE_ENV=production browserify index.js -t [ babelify ] -t [ envify ] > bundle.js`

## Expected Behavior

Messages intended for developers should be surrounded by `'production' !== 'production'` (or other env values for that matter) checks so that minification removes them.

## Actual Behavior

±3kb (gzipped) of development aid messages are kept in the bundle and make their way to production.