### PR TITLE
Remove add-module-exports babel plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,8 +4,7 @@
 
   "env": {
     "cjs": {
-      "presets": ["es2015-loose", "stage-1"],
-      "plugins": ["add-module-exports"]
+      "presets": ["es2015-loose", "stage-1"]
     },
     "es": {
       "presets": ["es2015-loose-native-modules", "stage-1"]

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "babel-core": "^6.7.6",
     "babel-eslint": "^5.0.4",
     "babel-loader": "^6.2.4",
-    "babel-plugin-add-module-exports": "^0.1.2",
     "babel-plugin-dev-expression": "^0.2.1",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-es2015-loose": "^7.0.0",


### PR DESCRIPTION
add-module-exports modifies the output only if there is a default export and no named exports. Both conditions are false now.