### PR TITLE
Mention react-router-optimize transform in docs to minimize bundle

### DIFF
--- a/docs/guides/MinimizingBundleSize.md
+++ b/docs/guides/MinimizingBundleSize.md
@@ -19,3 +19,5 @@ import Router from 'react-router/lib/Router'
 ```
 
 The public API available in this manner is defined as the set of imports available from the top-level `react-router` module. Anything not available through the top-level `react-router` module is a private API, and is subject to change without notice.
+
+Alternatively you can enable the [react-router-optimize](https://www.npmjs.com/package/babel-plugin-transform-react-router-optimize) babel transform to rewrite the imports automatically.


### PR DESCRIPTION
The "Minimize Bundle Size" guides explain how to reduce file size by
only importing the neccessary parts of react-router.
I created a small babel plugin to do this transformation automatically.
https://www.npmjs.com/package/babel-plugin-transform-react-router-optimize