### PR TITLE
Make `params` available to getChildRoutes providers

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -85,7 +85,7 @@ A function used to convert an object from [`<Link>`](#link)s or calls to
 A function used to convert a query string into an object that gets passed to route component props.
 
 ##### `onError(error)`
-While the router is matching, errors may bubble up, here is your opportunity to catch and deal with them. Typically these will come from async features like [`route.getComponents`](#getcomponentsnextstate-callback), [`route.getIndexRoute`](#getindexroutelocation-callback), and [`route.getChildRoutes`](#getchildroutesprogressstate-callback).
+While the router is matching, errors may bubble up, here is your opportunity to catch and deal with them. Typically these will come from async features like [`route.getComponents`](#getcomponentsnextstate-callback), [`route.getIndexRoute`](#getindexroutelocation-callback), and [`route.getChildRoutes`](#getchildroutespartialnextstate-callback).
 
 ##### `onUpdate()`
 Called whenever the router updates its state in response to URL changes.
@@ -368,8 +368,8 @@ A plain JavaScript object route definition. `<Router>` turns JSX `<Route>`s into
 ##### `childRoutes`
 An array of child routes, same as `children` in JSX route configs.
 
-##### `getChildRoutes(progressState, callback)`
-Same as `childRoutes` but asynchronous and receives the `progressState`. Useful for code-splitting and dynamic route matching (given some state or session data to return a different set of child routes).
+##### `getChildRoutes(partialNextState, callback)`
+Same as `childRoutes` but asynchronous and receives the `partialNextState`. Useful for code-splitting and dynamic route matching (given some state or session data to return a different set of child routes).
 
 ###### `callback` signature
 `cb(err, routesArray)`
@@ -399,8 +399,8 @@ let myRoute = {
 
 let myRoute = {
   path: 'picture/:id',
-  getChildRoutes(progressState, cb) {
-    let { state } = progressState
+  getChildRoutes(partialNextState, cb) {
+    let { state } = partialNextState
 
     if (state && state.fromDashboard) {
       cb(null, [dashboardPictureRoute])

--- a/docs/API.md
+++ b/docs/API.md
@@ -85,7 +85,7 @@ A function used to convert an object from [`<Link>`](#link)s or calls to
 A function used to convert a query string into an object that gets passed to route component props.
 
 ##### `onError(error)`
-While the router is matching, errors may bubble up, here is your opportunity to catch and deal with them. Typically these will come from async features like [`route.getComponents`](#getcomponentsnextstate-callback), [`route.getIndexRoute`](#getindexroutelocation-callback), and [`route.getChildRoutes`](#getchildrouteslocation-callback).
+While the router is matching, errors may bubble up, here is your opportunity to catch and deal with them. Typically these will come from async features like [`route.getComponents`](#getcomponentsnextstate-callback), [`route.getIndexRoute`](#getindexroutelocation-callback), and [`route.getChildRoutes`](#getchildroutesprogressstate-callback).
 
 ##### `onUpdate()`
 Called whenever the router updates its state in response to URL changes.
@@ -368,8 +368,8 @@ A plain JavaScript object route definition. `<Router>` turns JSX `<Route>`s into
 ##### `childRoutes`
 An array of child routes, same as `children` in JSX route configs.
 
-##### `getChildRoutes(location, callback)`
-Same as `childRoutes` but asynchronous and receives the `location`. Useful for code-splitting and dynamic route matching (given some state or session data to return a different set of child routes).
+##### `getChildRoutes(progressState, callback)`
+Same as `childRoutes` but asynchronous and receives the `progressState`. Useful for code-splitting and dynamic route matching (given some state or session data to return a different set of child routes).
 
 ###### `callback` signature
 `cb(err, routesArray)`
@@ -399,8 +399,8 @@ let myRoute = {
 
 let myRoute = {
   path: 'picture/:id',
-  getChildRoutes(location, cb) {
-    let { state } = location
+  getChildRoutes(progressState, cb) {
+    let { state } = progressState
 
     if (state && state.fromDashboard) {
       cb(null, [dashboardPictureRoute])

--- a/docs/guides/DynamicRouting.md
+++ b/docs/guides/DynamicRouting.md
@@ -10,7 +10,7 @@ A router is the perfect place to handle code splitting: it's responsible for set
 
 React Router does all of its [path matching](/docs/guides/RouteMatching.md) and component fetching asynchronously, which allows you to not only load up the components lazily, *but also lazily load the route configuration*. You really only need one route definition in your initial bundle, the router can resolve the rest on demand.
 
-Routes may define [`getChildRoutes`](/docs/API.md#getchildroutesprogressstate-callback), [`getIndexRoute`](/docs/API.md#getindexroutelocation-callback), and [`getComponents`](/docs/API.md#getcomponentsnextstate-callback) methods. These are asynchronous and only called when needed. We call it "gradual matching". React Router will gradually match the URL and fetch only the amount of route configuration and components it needs to match the URL and render.
+Routes may define [`getChildRoutes`](/docs/API.md#getchildroutespartialnextstate-callback), [`getIndexRoute`](/docs/API.md#getindexroutelocation-callback), and [`getComponents`](/docs/API.md#getcomponentsnextstate-callback) methods. These are asynchronous and only called when needed. We call it "gradual matching". React Router will gradually match the URL and fetch only the amount of route configuration and components it needs to match the URL and render.
 
 Coupled with a smart code splitting tool like [webpack](http://webpack.github.io/), a once tiresome architecture is now simple and declarative.
 
@@ -18,7 +18,7 @@ Coupled with a smart code splitting tool like [webpack](http://webpack.github.io
 const CourseRoute = {
   path: 'course/:courseId',
 
-  getChildRoutes(progressState, callback) {
+  getChildRoutes(partialNextState, callback) {
     require.ensure([], function (require) {
       callback(null, [
         require('./routes/Announcements'),

--- a/docs/guides/DynamicRouting.md
+++ b/docs/guides/DynamicRouting.md
@@ -10,7 +10,7 @@ A router is the perfect place to handle code splitting: it's responsible for set
 
 React Router does all of its [path matching](/docs/guides/RouteMatching.md) and component fetching asynchronously, which allows you to not only load up the components lazily, *but also lazily load the route configuration*. You really only need one route definition in your initial bundle, the router can resolve the rest on demand.
 
-Routes may define [`getChildRoutes`](/docs/API.md#getchildrouteslocation-callback), [`getIndexRoute`](/docs/API.md#getindexroutelocation-callback), and [`getComponents`](/docs/API.md#getcomponentsnextstate-callback) methods. These are asynchronous and only called when needed. We call it "gradual matching". React Router will gradually match the URL and fetch only the amount of route configuration and components it needs to match the URL and render.
+Routes may define [`getChildRoutes`](/docs/API.md#getchildroutesprogressstate-callback), [`getIndexRoute`](/docs/API.md#getindexroutelocation-callback), and [`getComponents`](/docs/API.md#getcomponentsnextstate-callback) methods. These are asynchronous and only called when needed. We call it "gradual matching". React Router will gradually match the URL and fetch only the amount of route configuration and components it needs to match the URL and render.
 
 Coupled with a smart code splitting tool like [webpack](http://webpack.github.io/), a once tiresome architecture is now simple and declarative.
 
@@ -18,7 +18,7 @@ Coupled with a smart code splitting tool like [webpack](http://webpack.github.io
 const CourseRoute = {
   path: 'course/:courseId',
 
-  getChildRoutes(location, callback) {
+  getChildRoutes(progressState, callback) {
     require.ensure([], function (require) {
       callback(null, [
         require('./routes/Announcements'),

--- a/examples/huge-apps/routes/Course/index.js
+++ b/examples/huge-apps/routes/Course/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   path: 'course/:courseId',
 
-  getChildRoutes(progressState, cb) {
+  getChildRoutes(partialNextState, cb) {
     require.ensure([], (require) => {
       cb(null, [
         require('./routes/Announcements'),

--- a/examples/huge-apps/routes/Course/index.js
+++ b/examples/huge-apps/routes/Course/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   path: 'course/:courseId',
 
-  getChildRoutes(location, cb) {
+  getChildRoutes(progressState, cb) {
     require.ensure([], (require) => {
       cb(null, [
         require('./routes/Announcements'),

--- a/examples/huge-apps/routes/Course/routes/Announcements/index.js
+++ b/examples/huge-apps/routes/Course/routes/Announcements/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   path: 'announcements',
 
-  getChildRoutes(location, cb) {
+  getChildRoutes(progressState, cb) {
     require.ensure([], (require) => {
       cb(null, [
         require('./routes/Announcement')

--- a/examples/huge-apps/routes/Course/routes/Announcements/index.js
+++ b/examples/huge-apps/routes/Course/routes/Announcements/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   path: 'announcements',
 
-  getChildRoutes(progressState, cb) {
+  getChildRoutes(partialNextState, cb) {
     require.ensure([], (require) => {
       cb(null, [
         require('./routes/Announcement')

--- a/examples/huge-apps/routes/Course/routes/Assignments/index.js
+++ b/examples/huge-apps/routes/Course/routes/Assignments/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   path: 'assignments',
 
-  getChildRoutes(progressState, cb) {
+  getChildRoutes(partialNextState, cb) {
     require.ensure([], (require) => {
       cb(null, [
         require('./routes/Assignment')

--- a/examples/huge-apps/routes/Course/routes/Assignments/index.js
+++ b/examples/huge-apps/routes/Course/routes/Assignments/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   path: 'assignments',
 
-  getChildRoutes(location, cb) {
+  getChildRoutes(progressState, cb) {
     require.ensure([], (require) => {
       cb(null, [
         require('./routes/Assignment')

--- a/modules/__tests__/matchRoutes-test.js
+++ b/modules/__tests__/matchRoutes-test.js
@@ -310,7 +310,7 @@ describe('matchRoutes', function () {
         <Route name="users"
                path="users"
                getChildRoutes={getChildRoutes}
-               getIndexRoute={getIndexRoute} /> 
+               getIndexRoute={getIndexRoute} />
       ])
 
       makeJsxNestedRoutes = () => {

--- a/modules/__tests__/matchRoutes-test.js
+++ b/modules/__tests__/matchRoutes-test.js
@@ -262,7 +262,7 @@ describe('matchRoutes', function () {
         if (childRoutes) {
           delete route.childRoutes
 
-          route.getChildRoutes = function (location, callback) {
+          route.getChildRoutes = function (progressState, callback) {
             setTimeout(function () {
               callback(null, childRoutes)
             })
@@ -294,7 +294,7 @@ describe('matchRoutes', function () {
     let getChildRoutes, getIndexRoute, jsxRoutes
 
     beforeEach(function () {
-      getChildRoutes = function (location, callback) {
+      getChildRoutes = function (progressState, callback) {
         setTimeout(function () {
           callback(null, <Route path=":userID" />)
         })

--- a/modules/__tests__/matchRoutes-test.js
+++ b/modules/__tests__/matchRoutes-test.js
@@ -262,7 +262,7 @@ describe('matchRoutes', function () {
         if (childRoutes) {
           delete route.childRoutes
 
-          route.getChildRoutes = function (progressState, callback) {
+          route.getChildRoutes = function (partialNextState, callback) {
             setTimeout(function () {
               callback(null, childRoutes)
             })
@@ -294,7 +294,7 @@ describe('matchRoutes', function () {
     let getChildRoutes, getIndexRoute, jsxRoutes
 
     beforeEach(function () {
-      getChildRoutes = function (progressState, callback) {
+      getChildRoutes = function (partialNextState, callback) {
         setTimeout(function () {
           callback(null, <Route path=":userID" />)
         })

--- a/modules/__tests__/matchRoutes-test.js
+++ b/modules/__tests__/matchRoutes-test.js
@@ -332,6 +332,35 @@ describe('matchRoutes', function () {
     })
   })
 
+  describe('a nested route with a getChildRoutes callback', function () {
+    let getChildRoutes, jsxRoutes
+
+    beforeEach(function () {
+      getChildRoutes = function (partialNextState, callback) {
+        setTimeout(function () {
+          callback(null, partialNextState)
+        })
+      }
+
+      jsxRoutes = createRoutes([
+        <Route name="users"
+               path="users/:id">
+          <Route name="topic"
+                path=":topic"
+                getChildRoutes={getChildRoutes} />
+        </Route>
+      ])
+    })
+
+    it('when getChildRoutes callback returns partialNextState', function (done) {
+      matchRoutes(jsxRoutes, createLocation('/users/5/details'), function (error, partialNextState) {
+        expect(partialNextState).toExist()
+        expect(partialNextState.params).toEqual({ id: '5', topic: 'details' })
+        done()
+      })
+    })
+  })
+
   it('complains about invalid index route with path', function (done) {
     shouldWarn('path')
 

--- a/modules/__tests__/matchRoutes-test.js
+++ b/modules/__tests__/matchRoutes-test.js
@@ -300,7 +300,7 @@ describe('matchRoutes', function () {
           callback(null, <Route path=":userID" />)
         })
       }
-      
+
       getIndexRoute = function (location, callback) {
         setTimeout(function () {
           callback(null, <Route name="jsx" />)

--- a/modules/__tests__/matchRoutes-test.js
+++ b/modules/__tests__/matchRoutes-test.js
@@ -325,7 +325,7 @@ describe('matchRoutes', function () {
         ])
         return { spy, routes }
       }
-    }) 
+    })
 
     it('when getChildRoutes callback returns reactElements', function (done) {
       matchRoutes(jsxRoutes, createLocation('/users/5'), function (error, match) {

--- a/modules/deprecateLocationProperties.js
+++ b/modules/deprecateLocationProperties.js
@@ -1,0 +1,31 @@
+import warning from './routerWarning'
+import { canUseMembrane } from './deprecateObjectProperties'
+
+// No-op by default.
+let deprecateLocationProperties = () => {}
+
+if (__DEV__ && canUseMembrane) {
+  deprecateLocationProperties = (nextState, location) => {
+    const nextStateWithLocation = { ...nextState }
+
+    // I don't use deprecateObjectProperties here because I want to keep the
+    // same code path between development and production, in that we just
+    // assign extra properties to the copy of the state object in both cases.
+    for (const prop in location) {
+      if (!Object.prototype.hasOwnProperty.call(location, prop)) {
+        continue
+      }
+
+      Object.defineProperty(nextStateWithLocation, prop, {
+        get() {
+          warning(false, 'Accessing location properties from the first argument to `getComponent` and `getComponents` is deprecated. That argument is now the router state (`nextState`) rather than the location. To access the location, use `nextState.location`.')
+          return location[prop]
+        }
+      })
+    }
+
+    return nextStateWithLocation
+  }
+}
+
+export default deprecateLocationProperties

--- a/modules/getComponents.js
+++ b/modules/getComponents.js
@@ -1,6 +1,6 @@
 import { mapAsync } from './AsyncUtils'
 import { canUseMembrane } from './deprecateObjectProperties'
-import warning from './routerWarning'
+import deprecateLocationProperties from './deprecateLocationProperties' 
 
 function getComponentsForRoute(nextState, route, callback) {
   if (route.component || route.components) {
@@ -18,23 +18,7 @@ function getComponentsForRoute(nextState, route, callback) {
   let nextStateWithLocation
 
   if (__DEV__ && canUseMembrane) {
-    nextStateWithLocation = { ...nextState }
-
-    // I don't use deprecateObjectProperties here because I want to keep the
-    // same code path between development and production, in that we just
-    // assign extra properties to the copy of the state object in both cases.
-    for (const prop in location) {
-      if (!Object.prototype.hasOwnProperty.call(location, prop)) {
-        continue
-      }
-
-      Object.defineProperty(nextStateWithLocation, prop, {
-        get() {
-          warning(false, 'Accessing location properties from the first argument to `getComponent` and `getComponents` is deprecated. That argument is now the router state (`nextState`) rather than the location. To access the location, use `nextState.location`.')
-          return location[prop]
-        }
-      })
-    }
+    nextStateWithLocation = deprecateLocationProperties(nextState, location)
   } else {
     nextStateWithLocation = { ...nextState, ...location }
   }

--- a/modules/getComponents.js
+++ b/modules/getComponents.js
@@ -1,6 +1,6 @@
 import { mapAsync } from './AsyncUtils'
 import { canUseMembrane } from './deprecateObjectProperties'
-import deprecateLocationProperties from './deprecateLocationProperties' 
+import deprecateLocationProperties from './deprecateLocationProperties'
 
 function getComponentsForRoute(nextState, route, callback) {
   if (route.component || route.components) {

--- a/modules/matchRoutes.js
+++ b/modules/matchRoutes.js
@@ -5,7 +5,7 @@ import { createRoutes } from './RouteUtils'
 import { canUseMembrane } from './deprecateObjectProperties'
 import deprecateLocationProperties from './deprecateLocationProperties' 
 
-function getChildRoutes(route, location, paramNames, paramValues, remainingPathname, callback) {
+function getChildRoutes(route, location, paramNames, paramValues, callback) {
   if (route.childRoutes) {
     return [ null, route.childRoutes ]
   }
@@ -15,8 +15,7 @@ function getChildRoutes(route, location, paramNames, paramValues, remainingPathn
 
   let sync = true, result, partialNextStateWithLocation
   const partialNextState = { 
-    params: createParams(paramNames, paramValues),
-    remainingPathname 
+    params: createParams(paramNames, paramValues)
   }
   
   if (__DEV__ && canUseMembrane) {
@@ -172,7 +171,7 @@ function matchRouteDeep(
       }
     }
 
-    const result = getChildRoutes(route, location, paramNames, paramValues, remainingPathname, onChildRoutes)
+    const result = getChildRoutes(route, location, paramNames, paramValues, onChildRoutes)
     if (result) {
       onChildRoutes(...result)
     }

--- a/modules/matchRoutes.js
+++ b/modules/matchRoutes.js
@@ -13,19 +13,19 @@ function getChildRoutes(route, location, paramNames, paramValues, remainingPathn
     return []
   }
 
-  let sync = true, result, progressStateWithLocation
-  const progressState = { 
+  let sync = true, result, partialNextStateWithLocation
+  const partialNextState = { 
     params: createParams(paramNames, paramValues),
     remainingPathname 
   }
   
   if (__DEV__ && canUseMembrane) {
-    progressStateWithLocation = deprecateLocationProperties(progressState, location)
+    partialNextStateWithLocation = deprecateLocationProperties(partialNextState, location)
   } else {
-    progressStateWithLocation = { ...progressState, ...location }
+    partialNextStateWithLocation = { ...partialNextState, ...location }
   }
 
-  route.getChildRoutes(progressStateWithLocation, function (error, childRoutes) {
+  route.getChildRoutes(partialNextStateWithLocation, function (error, childRoutes) {
     childRoutes = !error && createRoutes(childRoutes)
     if (sync) {
       result = [ error, childRoutes ]

--- a/modules/matchRoutes.js
+++ b/modules/matchRoutes.js
@@ -3,7 +3,7 @@ import { loopAsync } from './AsyncUtils'
 import { matchPattern } from './PatternUtils'
 import { createRoutes } from './RouteUtils'
 import { canUseMembrane } from './deprecateObjectProperties'
-import deprecateLocationProperties from './deprecateLocationProperties' 
+import deprecateLocationProperties from './deprecateLocationProperties'
 
 function getChildRoutes(route, location, paramNames, paramValues, callback) {
   if (route.childRoutes) {


### PR DESCRIPTION
As it says on the label, this is an initial POC of making `params` and `remainingPathname` available to `getChildRoutes` providers. This was instigated primarily via a discussion with @taion and a another minor discussion with @timdorr.

**Use Case**
The use case this is intended to help with is in cases where the child route to be returned by `getChildRoutes` is dependent on the `params` that have been evaluated so far. For instance, if I have `:country` as the path for the current route being matched, in the `getChildRoutes` function for that route, I want to be able to access the `country` param so that I can decide which child route should be returned for that country (it can be different in different cases). Additionally, I have other cases where I want to "read forward" into `remainingPathname` of the path to decide what child route should be returned. The later being a more minor use case.

Currently, without this patch, the only context I have available is the `location` arg, which is not that useful and which I end up having to parse manually. This is doable, but is tedious and leads to very brittle code (i.e. if you add/remove "upstream" path segments).

**Approach**
As discussed with @taion, this PR has been done in a "non breaking" fashion - it follows the same pattern as a similar commit which was done to `getComponent` - [here](https://github.com/reactjs/react-router/commit/3076dca3c4335cf8a18d09cd28bc2c651ca946de). This is done by making all the location properties available at the root level for non dev builds but adding warnings to usage of those properties in dev builds (again following the same logic as with `getComponent`). 

At the time of calling `getChildRoutes` we have access to the current `params` that have been available (which is what I am primarily after) and the remainder of the path that needs to yet to be parsed. As such, a state object is created with these values, plus the additional location properties, and passed into the registered `getChildRoutes`.

**Questions**
 - `progressState` vs `nextState` - Elsewhere in the system, this object is called `nextState`, I wasn't sure you would consider if this exactly matches the semantics at play here since technically its not the "final" state and doesn't match the same structure as the current `nextState`. Hence I have called this `progressState`. Do you agree with this, is there a better name or should it just be `nextState`?

**Note**
I have abstracted out the `deprecateLocationProperties` function from `getComponents` as the logic is exactly the same. I'm assuming this is appropriate/desirable. 

**Work to be done**
Assuming we are good with this PR and/or get to a point where we are good with it, I will finish off the, tests, samples update, docs, etc (inline with the work that was done with the `getComponent` [commit](https://github.com/reactjs/react-router/commit/3076dca3c4335cf8a18d09cd28bc2c651ca946de) mentioned earlier).