### PR TITLE
use es2015 object shorthand in examples

### DIFF
--- a/examples/auth-flow/app.js
+++ b/examples/auth-flow/app.js
@@ -12,7 +12,7 @@ const App = React.createClass({
 
   updateAuth(loggedIn) {
     this.setState({
-      loggedIn: loggedIn
+      loggedIn
     })
   },
 

--- a/examples/nested-animations/app.js
+++ b/examples/nested-animations/app.js
@@ -18,7 +18,7 @@ const App = ({ children, location: { pathname } }) => {
         component="div" transitionName="swap"
         transitionEnterTimeout={500} transitionLeaveTimeout={500}
       >
-        {React.cloneElement(children || <div />, { key: key })}
+        {React.cloneElement(children || <div />, { key })}
       </ReactCSSTransitionGroup>
     </div>
   )


### PR DESCRIPTION
Just a small change to use more es2015 in two of the examples.