### PR TITLE
pushed state information added

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -189,6 +189,8 @@ router.push({
 })
 ```
 
+The pushed state can be accessed from `this.props.location.state`.
+
 ##### `replace(pathOrLoc)`
 Identical to `push` except replaces the current history entry with a new one.
 


### PR DESCRIPTION
Added a line that explains how to access the pushed state from router.push. It's currently not really clear within the documentation. http://stackoverflow.com/questions/34169068/passing-state-via-this-history-pushstate