### PR TITLE
Don't check propTypes ahead of time

### DIFF
--- a/modules/RouteUtils.js
+++ b/modules/RouteUtils.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import warning from './routerWarning'
 
 function isValidChild(object) {
   return object == null || React.isValidElement(object)
@@ -9,20 +8,6 @@ export function isReactChildren(object) {
   return isValidChild(object) || (Array.isArray(object) && object.every(isValidChild))
 }
 
-function checkPropTypes(componentName, propTypes, props) {
-  componentName = componentName || 'UnknownComponent'
-
-  for (const propName in propTypes) {
-    if (Object.prototype.hasOwnProperty.call(propTypes, propName)) {
-      const error = propTypes[propName](props, propName, componentName)
-
-      /* istanbul ignore if: error logging */
-      if (error instanceof Error)
-        warning(false, error.message)
-    }
-  }
-}
-
 function createRoute(defaultProps, props) {
   return { ...defaultProps, ...props }
 }
@@ -30,9 +15,6 @@ function createRoute(defaultProps, props) {
 export function createRouteFromReactElement(element) {
   const type = element.type
   const route = createRoute(type.defaultProps, element.props)
-
-  if (type.propTypes)
-    checkPropTypes(type.displayName || type.name, type.propTypes, route)
 
   if (route.children) {
     const childRoutes = createRoutesFromReactChildren(route.children, route)
@@ -52,7 +34,7 @@ export function createRouteFromReactElement(element) {
  * nested.
  *
  *   import { Route, createRoutesFromReactChildren } from 'react-router'
- *   
+ *
  *   const routes = createRoutesFromReactChildren(
  *     <Route component={App}>
  *       <Route path="home" component={Dashboard}/>


### PR DESCRIPTION
We are adding a warning to React that warns when you call `PropTypes` validation functions by yourself. This is going to be unsupported as we want to make them behave more like black boxes so people stop calling them, and it would become safe for us to make them no-ops in production, saving some code size.

I tried the [new code](https://github.com/facebook/react/pull/7132) on some projects, and it appears that React Router calls propTypes directly generating the warnings: https://github.com/facebook/react/pull/7132#issuecomment-229534202.

I’m not sure how valuable that check was so I just removed it. If it’s super valuable, we can replace it with `React.createElement` call that would make React check the prop types, but in this case I’d need to have a test case verifying the behavior you wanted because I’m not sure I fully understand why this call is necessary.

I’d appreciate if you could merge this and cut a release (especially if you could also backport it to 2.x) because otherwise React is start emitting warnings about React Router in a month or so.