### PR TITLE
[change] add onEnter callback parameters to inject props on container.

### DIFF
--- a/modules/Router.js
+++ b/modules/Router.js
@@ -85,7 +85,23 @@ const Router = React.createClass({
       if (error) {
         this.handleError(error)
       } else {
-        this.setState(state, this.props.onUpdate)
+        let enterProps
+        if (this.state.routes) {
+          enterProps = {}
+          for (let i=0; i < state.routes.length; ++i) {
+            if (state.routes[i] === this.state.routes[i]) {
+              enterProps[i] = this.state.enterProps[i]
+            } else {
+              enterProps[i] = state.enterProps[i]
+            }
+          }
+        } else {
+          enterProps = state.enterProps
+        }
+        this.setState({
+          ...state,
+          enterProps
+        }, this.props.onUpdate)
       }
     })
 
@@ -171,6 +187,7 @@ const Router = React.createClass({
 
     return render({
       ...props,
+      enterProps: this.state.enterProps,
       history: this.history,
       router: this.router,
       location,

--- a/modules/RouterContext.js
+++ b/modules/RouterContext.js
@@ -16,6 +16,7 @@ const RouterContext = React.createClass({
 
   propTypes: {
     history: object,
+    enterProps: object,
     router: object.isRequired,
     location: object.isRequired,
     routes: array.isRequired,
@@ -70,13 +71,15 @@ const RouterContext = React.createClass({
 
         const route = routes[index]
         const routeParams = getRouteParams(route, params)
+        const enterProp = this.props.enterProps ? this.props.enterProps[index] : null
         const props = {
           history,
           location,
           params,
           route,
           routeParams,
-          routes
+          routes,
+          ...enterProp
         }
 
         if (isReactChildren(element)) {

--- a/modules/createTransitionManager.js
+++ b/modules/createTransitionManager.js
@@ -84,7 +84,7 @@ export default function createTransitionManager(history, routes) {
       runEnterHooks(enterRoutes, nextState, finishEnterHooks)
     })
 
-    function finishEnterHooks(error, redirectInfo) {
+    function finishEnterHooks(error, redirectInfo, enterProps) {
       if (error || redirectInfo)
         return handleErrorOrRedirect(error, redirectInfo)
 
@@ -96,7 +96,7 @@ export default function createTransitionManager(history, routes) {
           // TODO: Make match a pure function and have some other API
           // for "match and update state".
           callback(null, null, (
-            state = { ...nextState, components })
+            state = { ...nextState, enterProps, components }),
           )
         }
       })


### PR DESCRIPTION
I changed onEnter callback to inject props.

onEnter(nextState : object, replace : function,  ?callback : function(error, redirectInfo, asyncProps))

second parameter will not works right now. I added this parameter to keep consistency.
It will look like 'match' functions callback.
maybe we can use this parameter as alternative of 'replace' function
third parameter will passing into container component.

Here is example
```
<Route path="test" component={TestContainer} onEnter={(nextState, replace, callback) => {
  callback(null, null, { injectProps: 'hello world!' });
}}>
```
TestContainer will have injectProps,
