### PR TITLE
Lifecycle events order correction

### DIFF
--- a/docs/guides/ComponentLifecycle.md
+++ b/docs/guides/ComponentLifecycle.md
@@ -24,8 +24,8 @@ Consider this route config:
 
     | Component | Lifecycle Hooks called |
     |-----------|------------------------|
-    | App | (2) `componentDidMount` |
-    | Home | (1) `componentDidMount` |
+    | App | (1) `componentDidMount` |
+    | Home | (2) `componentDidMount` |
     | Invoice | N/A |
     | Account | N/A |
 


### PR DESCRIPTION
In the ComponentLifecycle guide, paradigm 1, shouldn't first occur "componentDidMount" in the App component and then in the Home component?