### PR TITLE
Feature-flagged conditional routes, externalContext proposal

### DIFF
--- a/modules/RouteUtils.js
+++ b/modules/RouteUtils.js
@@ -12,12 +12,12 @@ function createRoute(defaultProps, props) {
   return { ...defaultProps, ...props }
 }
 
-export function createRouteFromReactElement(element) {
+export function createRouteFromReactElement(element, parentRoute, externalContext) {
   const type = element.type
   const route = createRoute(type.defaultProps, element.props)
 
   if (route.children) {
-    const childRoutes = createRoutesFromReactChildren(route.children, route)
+    const childRoutes = createRoutesFromReactChildren(route.children, route, externalContext)
 
     if (childRoutes.length)
       route.childRoutes = childRoutes
@@ -45,19 +45,19 @@ export function createRouteFromReactElement(element) {
  * Note: This method is automatically used when you provide <Route> children
  * to a <Router> component.
  */
-export function createRoutesFromReactChildren(children, parentRoute) {
+export function createRoutesFromReactChildren(children, parentRoute, externalContext) {
   const routes = []
 
   React.Children.forEach(children, function (element) {
     if (React.isValidElement(element)) {
       // Component classes may have a static create* method.
       if (element.type.createRouteFromReactElement) {
-        const route = element.type.createRouteFromReactElement(element, parentRoute)
+        const route = element.type.createRouteFromReactElement(element, parentRoute, externalContext)
 
         if (route)
           routes.push(route)
       } else {
-        routes.push(createRouteFromReactElement(element))
+        routes.push(createRouteFromReactElement(element, null, externalContext))
       }
     }
   })
@@ -69,9 +69,9 @@ export function createRoutesFromReactChildren(children, parentRoute) {
  * Creates and returns an array of routes from the given object which
  * may be a JSX route, a plain object route, or an array of either.
  */
-export function createRoutes(routes) {
+export function createRoutes(routes, externalContext) {
   if (isReactChildren(routes)) {
-    routes = createRoutesFromReactChildren(routes)
+    routes = createRoutesFromReactChildren(routes, null, externalContext)
   } else if (routes && !Array.isArray(routes)) {
     routes = [ routes ]
   }

--- a/modules/Router.js
+++ b/modules/Router.js
@@ -20,7 +20,7 @@ function isUnsupportedHistory(history) {
   return history && history.getCurrentLocation
 }
 
-const { func, object } = React.PropTypes
+const { func, object, any } = React.PropTypes
 
 /**
  * A <Router> is a high-level API for automatically setting up
@@ -37,6 +37,7 @@ const Router = React.createClass({
     createElement: func,
     onError: func,
     onUpdate: func,
+    externalContext: any,
 
     // Deprecated:
     parseQueryString: func,
@@ -100,7 +101,7 @@ const Router = React.createClass({
     }
 
     let { history } = this.props
-    const { routes, children } = this.props
+    const { routes, children, externalContext } = this.props
 
     invariant(
       !isUnsupportedHistory(history),
@@ -114,7 +115,7 @@ const Router = React.createClass({
     }
 
     const transitionManager = createTransitionManager(
-      history, createRoutes(routes || children)
+      history, createRoutes(routes || children, externalContext)
     )
     const router = createRouterObject(history, transitionManager)
     const routingHistory = createRoutingHistory(history, transitionManager)

--- a/modules/match.js
+++ b/modules/match.js
@@ -14,7 +14,7 @@ import { createRouterObject, createRoutingHistory } from './RouterUtils'
  * Note: You probably don't want to use this in a browser unless you're using
  * server-side rendering with async routes.
  */
-function match({ history, routes, location, ...options }, callback) {
+function match({ history, routes, location, externalContext, ...options }, callback) {
   invariant(
     history || location,
     'match needs a history or a location'
@@ -23,7 +23,7 @@ function match({ history, routes, location, ...options }, callback) {
   history = history ? history : createMemoryHistory(options)
   const transitionManager = createTransitionManager(
     history,
-    createRoutes(routes)
+    createRoutes(routes, externalContext)
   )
 
   let unlisten


### PR DESCRIPTION
## Proposal
Accept `externalContext` property for `<Router />` and `match({ externalContext })` and pass it along to route configuration (to `createRouteFromReactElement`, `getChildRoutes` etc).

## Use case
I'm trying to implement clean feature flags approach.
First thought would be to implement it through plain JS. Example:

*SomeComponent.jsx*:
```jsx
render() {
  return (
    <div>
      ...
      {featureFlags.feature1 && (
        ... render this if feature1 is enabled
      )}
      ...
    </div>
  );
}
```

*routes.js*:
```jsx
export default (featureFlags) => (
  <Route>
    <Route path="about" component={...} />
    {featureFlags.feature1 && (
      <Route path="feature1" component={...} />
    )}
  </Route>
);
```

This might be good enough, but I thought it would be nice to write clean JSX. Example:
*SomeComponent.jsx*:
```jsx
render() {
  return (
    <div>
      ...
      <FeatureFlag on="feature1">
        ... render this if feature1 is enabled
      </FeatureFlag>
      ...
    </div>
  );
}
```

*routes.js*:
```jsx
export default (
  <Route>
    <Route path="about" component={...} />
    <FeatureFlag on="feature1">
      <Route path="feature1" component={...} />
    </FeatureFlag>
  </Route>
);
```
But Router does not "render" (and does not instantiate) `FeatureFlag` component. It just uses JSX as convenient method to define route configuration tree.

## Implementation idea
To make last example work, I dove into React Router code and ended up with code like this:
*FeatureFlag.js*:
```jsx
class FeatureFlag extends React.Component {
  static createRouteFromReactElement(element, parentRoute) {
    if (... CONDITION ...) {
      return {childRoutes: createRoutes(element.props.children)};
    }
    return null;
  }
}
```
This allows to pass through child routes by certain condition.
The problem is that there is no enough information in scope of `createRouteFromReactElement` to perform `CONDITION`.

If I could provide something into router (into `<Router />` client-side and `match` server-side) and read that something in `createRouteFromReactElement`, then I get full power to implement desired feature flags approach (and so nice JSX conditional routes).

## Next steps
This PR's code changes show possible way of passing along `externalContext`, which solves my use case.
In order to make this PR consistent and ready for merge, I would need to provide similar functionality to `getChildRoutes` as well (to support async routing) and write corresponding tests.

Before burning down this into PR (and depend on that in my codebase), I'd like to get maintainer's opinion on whether it's worth continuing.
Thanks!