### PR TITLE
Add an example on how to use the onEnter callback

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -345,6 +345,28 @@ Called when a route is about to be entered. It provides the next router state an
 
 If `callback` is listed as a 3rd argument, this hook will run asynchronously, and the transition will block until `callback` is called.
 
+###### `callback` signature
+`cb(err)`
+
+```js
+const userIsInAnOrganisation = (nextState, replace, callback) => {
+  fetch(...)
+    .then(response = response.json())
+    .then(userOrganisations => {
+      if (userOrganisations.length === 0) {
+        replace({
+          pathname: '/users/' + nextState.params.userId + '/organisations/new',
+          state: { nextPathname: nextState.location.pathname }
+        })
+        
+        callback(null);
+      }
+    })
+}
+
+<Route path="/users/:userId/organisations" onEnter={userIsInAnOrganisation} />
+```
+
 ##### `onChange(prevState, nextState, replace, callback?)`
 Called on routes when the location changes, but the route itself neither enters or leaves. For example, this will be called when a route's children change, or when the location query changes. It provides the previous router state, the next router state, and a function to redirect to another path. `this` will be the route instance that triggered the hook.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -349,21 +349,25 @@ If `callback` is listed as a 3rd argument, this hook will run asynchronously, an
 `cb(err)`
 
 ```js
-const userIsInAnOrganisation = (nextState, replace, callback) => {
+const userIsInAnTeam = (nextState, replace, callback) => {
   fetch(...)
     .then(response = response.json())
-    .then(userOrganisations => {
-      if (userOrganisations.length === 0) {
+    .then(userTeams => {
+      if (userTeams.length === 0) {
         replace({
-          pathname: '/users/' + nextState.params.userId + '/organisations/new',
+          pathname: '/users/' + nextState.params.userId + '/teams/new',
           state: { nextPathname: nextState.location.pathname }
         })
       }
       callback();
     })
+    .catch(error => {
+      // do some async error handling here
+      callback();
+    })
 }
 
-<Route path="/users/:userId/organisations" onEnter={userIsInAnOrganisation} />
+<Route path="/users/:userId/teams" onEnter={userIsInAnTeam} />
 ```
 
 ##### `onChange(prevState, nextState, replace, callback?)`

--- a/docs/API.md
+++ b/docs/API.md
@@ -349,25 +349,22 @@ If `callback` is listed as a 3rd argument, this hook will run asynchronously, an
 `cb(err)`
 
 ```js
-const userIsInAnTeam = (nextState, replace, callback) => {
+const userIsInATeam = (nextState, replace, callback) => {
   fetch(...)
     .then(response = response.json())
     .then(userTeams => {
       if (userTeams.length === 0) {
-        replace({
-          pathname: '/users/' + nextState.params.userId + '/teams/new',
-          state: { nextPathname: nextState.location.pathname }
-        })
+        replace(`/users/${nextState.params.userId}/teams/new`)
       }
       callback();
     })
     .catch(error => {
       // do some error handling here
-      callback();
+      callback(error);
     })
 }
 
-<Route path="/users/:userId/teams" onEnter={userIsInAnTeam} />
+<Route path="/users/:userId/teams" onEnter={userIsInATeam} />
 ```
 
 ##### `onChange(prevState, nextState, replace, callback?)`

--- a/docs/API.md
+++ b/docs/API.md
@@ -358,9 +358,8 @@ const userIsInAnOrganisation = (nextState, replace, callback) => {
           pathname: '/users/' + nextState.params.userId + '/organisations/new',
           state: { nextPathname: nextState.location.pathname }
         })
-        
-        callback(null);
       }
+      callback();
     })
 }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -362,7 +362,7 @@ const userIsInAnTeam = (nextState, replace, callback) => {
       callback();
     })
     .catch(error => {
-      // do some async error handling here
+      // do some error handling here
       callback();
     })
 }


### PR DESCRIPTION
This change adds an example to the documentation on how to use the onEnter callback to redirect a user to another page.