### PR TITLE
Add module entry point for webpack 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "umd"
   ],
   "main": "lib/index",
+  "module": "es/index",
   "jsnext:main": "es/index",
   "repository": "reactjs/react-router",
   "homepage": "https://github.com/reactjs/react-router#readme",


### PR DESCRIPTION
This is what webpack 2 prefers. Ideally Rollup will follow along as well.