### PR TITLE
Fix handling of patterns that are method names

### DIFF
--- a/modules/PatternUtils.js
+++ b/modules/PatternUtils.js
@@ -49,10 +49,10 @@ function _compilePattern(pattern) {
   }
 }
 
-const CompiledPatternsCache = {}
+const CompiledPatternsCache = Object.create(null)
 
 export function compilePattern(pattern) {
-  if (!(pattern in CompiledPatternsCache))
+  if (!CompiledPatternsCache[pattern])
     CompiledPatternsCache[pattern] = _compilePattern(pattern)
 
   return CompiledPatternsCache[pattern]

--- a/modules/__tests__/getParamNames-test.js
+++ b/modules/__tests__/getParamNames-test.js
@@ -19,4 +19,10 @@ describe('getParamNames', function () {
       expect(getParamNames('/files/*.jpg')).toEqual([ 'splat' ])
     })
   })
+
+  describe('when a pattern has the same name as a built-in method', function () {
+    it('should work', function () {
+      expect(getParamNames('toString')).toEqual([])
+    })
+  })
 })

--- a/modules/__tests__/matchPattern-test.js
+++ b/modules/__tests__/matchPattern-test.js
@@ -41,4 +41,8 @@ describe('matchPattern', function () {
     assertMatch('/**/*.jpg', '/files/path/to/file.jpg', '', [ 'splat', 'splat' ], [ 'files/path/to', 'file' ])
   })
 
+  it('works with patterns that match built-in names', function () {
+    assertMatch('toString', '/toString', '', [], [])
+  })
+
 })


### PR DESCRIPTION
Fixes #3679.

Includes #3678 (needed for CI to pass).

`PatternUtils` is sort of a mess, incidentally. There's no reason to export `compilePattern`, and there's no real reason that `getParams` should still exist (nothing calls it). I also don't know why `getRouteParams` is completely separate module, either.

I want to fix/deprecate, but it's not that compelling right now.