### PR TITLE
add note about possible use case for memoryHistory

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -622,7 +622,7 @@ For more details, please see the [histories guide](/docs/guides/Histories.md).
 
 
 ### `createMemoryHistory(options)`
-`createMemoryHistory` creates an in-memory `history` object that does not interact with the browser URL. This is useful when you need to customize the `history` used for server-side rendering, as well as for automated testing.
+`createMemoryHistory` creates an in-memory `history` object that does not interact with the browser URL. This is useful when you need to customize the `history` used for server-side rendering, as well as for automated testing or cases where you cannot/should not manipulate the browser history (for example when your application gets embedded in an iframe).
 
 
 ### `useRouterHistory(createHistory)`


### PR DESCRIPTION
While developing a widget which is meant to be embedded into websites
via an iframe, we noticed `history` taking over the parent page’s
back/forward button (not a bug, just the way browser history works). We
were able to isolate the routing to the widget by using
`memoryHistory`.

This PR just adds a tiny note that `createMemoryHistory` can be useful
for a case like that.