### PR TITLE
add "ref" support to JSX route definitions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## [v2.6.1]
 > Jul 29, 2016
 
+- **Feature:** Add support for `ref` hook on JSX routes ([#TODO])
 - **Bugfix:** Correctly handle routes with patterns that are the names of properties on `Object.prototype` ([#3680])
 
 [v2.6.1]: https://github.com/reactjs/react-router/compare/v2.6.0...v2.6.1

--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -17,6 +17,7 @@ This is a glossary of common terms used in the React Router codebase and documen
 * [Query](#query)
 * [QueryString](#querystring)
 * [RedirectFunction](#redirectfunction)
+* [Ref](#ref)
 * [Route](#route)
 * [RouteComponent](#routecomponent)
 * [RouteConfig](#routeconfig)
@@ -174,6 +175,14 @@ type RedirectFunction = (state: ?LocationState, pathname: Pathname | Path, query
 ```
 
 A *redirect function* is used in [`onEnter` hooks](#enterhook) to trigger a transition to a new URL.
+
+## Ref
+
+```jsx
+type RefHook = (route: Route, parent: ?Route) => any;
+```
+
+A *ref hook* is a user-defined function that is called when a route definition is created. It receives the route itself as its first argument and optionally the parent route (if any).
 
 ## Route
 

--- a/docs/guides/RouteConfiguration.md
+++ b/docs/guides/RouteConfiguration.md
@@ -178,6 +178,24 @@ Continuing with our example above, if a user clicked on a link to `/about` from 
   - `onLeave` on the `/inbox` route
   - `onEnter` on the `/about` route
 
+
+
+### Refs
+
+[Route](/docs/Glossary.md#route)s may also define [`ref`](/docs/Glossary.md#ref) hooks that are invoked once a route is instantiated. These hooks are useful when a route is created and you want to keep a reference to it, but you prefer JSX.
+
+```jsx
+let usersRoute
+
+render((
+  <Router>
+    <Route path="/" component={Parent}>
+      <Rote ref={ (route, parentRoute) => usersRoute = route} path="users" component={Users} />
+    </Route>
+  </Router>
+), document.body)
+```
+
 ### Configuration with Plain Routes
 
 Since [routes](/docs/Glossary.md#route) are usually nested, it's useful to use a concise nested syntax like [JSX](https://facebook.github.io/jsx/) to describe their relationship to one another. However, you may also use an array of plain [route](/docs/Glossary.md#route) objects if you prefer to avoid using JSX.

--- a/modules/RouteUtils.js
+++ b/modules/RouteUtils.js
@@ -50,15 +50,19 @@ export function createRoutesFromReactChildren(children, parentRoute) {
 
   React.Children.forEach(children, function (element) {
     if (React.isValidElement(element)) {
+      let route
       // Component classes may have a static create* method.
       if (element.type.createRouteFromReactElement) {
-        const route = element.type.createRouteFromReactElement(element, parentRoute)
-
-        if (route)
-          routes.push(route)
+        route = element.type.createRouteFromReactElement(element, parentRoute)
       } else {
-        routes.push(createRouteFromReactElement(element))
+        route = createRouteFromReactElement(element)
       }
+
+      if (element.ref)
+        element.ref(route, parentRoute)
+
+      if (route)
+        routes.push(route)
     }
   })
 

--- a/modules/__tests__/createRoutesFromReactChildren-test.js
+++ b/modules/__tests__/createRoutesFromReactChildren-test.js
@@ -108,4 +108,21 @@ describe('createRoutesFromReactChildren', function () {
     ])
   })
 
+  describe('when the route definition has "ref" property', function () {
+    it('calls it', function () {
+      let routeRef
+      createRoutesFromReactChildren([
+        <Route ref={ route => routeRef = route } path="/one" component={Hello} />
+      ])
+
+      expect(routeRef).toEqual(
+        {
+          path: '/one',
+          component: Hello
+        }
+      )
+    })
+  })
+
+
 })


### PR DESCRIPTION
Hi!

I have a use-case where I need to save a reference to the route definition, but my routes are declared in JSX.

Given React background, I expected `ref` to work in JSX, but it's not. 

This PR makes it possible to receive `ref` callback when route is created:

```jsx
let usersRoute

render((
  <Router>
    <Rote ref={ route => usersRoute = route} path="users" component={Users} />
  </Router>
), document.body)
```