### PR TITLE
Update README.md to clarify versioning scheme vs versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ See more in the [Introduction](/docs/Introduction.md), [Guides](/docs/guides/REA
 
 ### Versioning and Stability
 
-We want React Router to be a stable dependency that’s easy to keep current. We follow the same versioning as React.js itself: [React Versioning Scheme](https://facebook.github.io/react/blog/2016/02/19/new-versioning-scheme.html).
+We want React Router to be a stable dependency that’s easy to keep current. We take the same approach to versioning as React.js itself: [React Versioning Scheme](https://facebook.github.io/react/blog/2016/02/19/new-versioning-scheme.html).
 
 ### Thanks
 


### PR DESCRIPTION
When I read React Router's versioning explanation, I thought the statement "We follow the same versioning as React.js itself" meant that I could use React Router 0.14.8 with React 0.14.8 (which is what React does with addons and ReactDOM packages in npm). I didn't realize that it was just the versioning /scheme/ which was consistent, not the version numbers themselves. I updated the language just slightly to reflect that.

Feel free to discard or merge as you see fit!