### PR TITLE
Warn on invalid middlewares

### DIFF
--- a/modules/__tests__/applyRouterMiddleware-test.js
+++ b/modules/__tests__/applyRouterMiddleware-test.js
@@ -5,6 +5,7 @@ import Router from '../Router'
 import Route from '../Route'
 import createMemoryHistory from '../createMemoryHistory'
 import applyMiddleware from '../applyRouterMiddleware'
+import shouldWarn from './shouldWarn'
 
 const FOO_ROOT_CONTAINER_TEXT = 'FOO ROOT CONTAINER'
 const BAR_ROOT_CONTAINER_TEXT = 'BAR ROOT CONTAINER'
@@ -141,4 +142,14 @@ describe('applyMiddleware', () => {
     })
   })
 
+  it('should warn on invalid middleware', () => {
+    shouldWarn('at index 0 does not appear to be a valid')
+    shouldWarn('at index 2 does not appear to be a valid')
+
+    applyMiddleware(
+      {},
+      { renderRouterContext: () => {} },
+      {}
+    )
+  })
 })

--- a/modules/applyRouterMiddleware.js
+++ b/modules/applyRouterMiddleware.js
@@ -1,9 +1,25 @@
 import React, { createElement } from 'react'
 import RouterContext from './RouterContext'
+import warning from './routerWarning'
 
 export default (...middlewares) => {
-  const withContext = middlewares.map(m => m.renderRouterContext).filter(f => f)
-  const withComponent = middlewares.map(m => m.renderRouteComponent).filter(f => f)
+  if (__DEV__) {
+    middlewares.forEach((middleware, index) => {
+      warning(
+        middleware.renderRouterContext || middleware.renderRouteComponent,
+        `The middleware specified at index ${index} does not appear to be ` +
+        'a valid React Router middleware.'
+      )
+    })
+  }
+
+  const withContext = middlewares
+    .map(middleware => middleware.renderRouterContext)
+    .filter(Boolean)
+  const withComponent = middlewares
+    .map(middleware => middleware.renderRouteComponent)
+    .filter(Boolean)
+
   const makeCreateElement = (baseCreateElement = createElement) => (
     (Component, props) => (
       withComponent.reduceRight(


### PR DESCRIPTION
Right now, if you pass in a value with properties that is not a valid React Router middleware, we just silently ignore it. This leads to really confusing things happening like https://github.com/relay-tools/react-router-relay/issues/189.

I don't think anybody's intentionally passing in empty objects to `applyRouterMiddleware`, so this should be a nice DX convenience.