### PR TITLE
Add Promise support to async route functions

### DIFF
--- a/modules/PromiseUtils.js
+++ b/modules/PromiseUtils.js
@@ -1,0 +1,3 @@
+export function isPromise(obj) {
+  return obj && typeof obj.then === 'function'
+}

--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -394,7 +394,7 @@ describe('Router', function () {
     it('should support getComponent returning a Promise', function (done) {
       const Component = () => <div />
 
-      const getComponent = () => new Promise((resolve) => resolve(Component))
+      const getComponent = () => new Promise(resolve => resolve(Component))
 
       render((
         <Router history={createHistory('/')} render={renderSpy}>

--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -391,6 +391,23 @@ describe('Router', function () {
       })
     })
 
+    it('should support getComponent returning a Promise', function (done) {
+      const Component = () => <div />
+
+      const getComponent = () => new Promise((resolve) => resolve(Component))
+
+      render((
+        <Router history={createHistory('/')} render={renderSpy}>
+          <Route path="/" getComponent={getComponent} />
+        </Router>
+      ), node, function () {
+        setTimeout(function () {
+          expect(componentSpy).toHaveBeenCalledWith([ Component ])
+          done()
+        })
+      })
+    })
+
   })
 
   describe('error handling', function () {

--- a/modules/__tests__/matchRoutes-test.js
+++ b/modules/__tests__/matchRoutes-test.js
@@ -290,6 +290,34 @@ describe('matchRoutes', function () {
     describeRoutes()
   })
 
+  describe('a Promise-based route config', function () {
+    function makeAsyncRouteConfig(routes) {
+      routes.forEach(function (route) {
+        const { childRoutes, indexRoute } = route
+
+        if (childRoutes) {
+          delete route.childRoutes
+
+          route.getChildRoutes = () => new Promise(resolve => resolve(childRoutes))
+
+          makeAsyncRouteConfig(childRoutes)
+        }
+
+        if (indexRoute) {
+          delete route.indexRoute
+
+          route.getIndexRoute = () => new Promise(resolve => resolve(indexRoute))
+        }
+      })
+    }
+
+    beforeEach(function () {
+      makeAsyncRouteConfig(routes)
+    })
+
+    describeRoutes()
+  })
+
   describe('an asynchronous JSX route config', function () {
     let getChildRoutes, getIndexRoute, jsxRoutes
 

--- a/modules/getComponents.js
+++ b/modules/getComponents.js
@@ -12,8 +12,6 @@ function getComponentsForRoute(nextState, route, callback) {
     const componentReturn = getComponent.call(route, nextState, callback)
     if (isPromise(componentReturn))
       componentReturn
-        // Try module.default first in case of System.import and Babel 6
-        .then(component => component.default || component)
         .then(
           component => callback(null, component),
           callback

--- a/modules/getComponents.js
+++ b/modules/getComponents.js
@@ -11,11 +11,10 @@ function getComponentsForRoute(nextState, route, callback) {
   if (getComponent) {
     const componentReturn = getComponent.call(route, nextState, callback)
     if (isPromise(componentReturn))
-      componentReturn.then(
+      componentReturn
         // Try module.default first in case of System.import
-        component => callback(null, component.default || component),
-        callback
-      ).catch(callback)
+        .then(component => callback(null, component.default || component))
+        .catch(callback)
   } else {
     callback()
   }

--- a/modules/getComponents.js
+++ b/modules/getComponents.js
@@ -1,4 +1,5 @@
 import { mapAsync } from './AsyncUtils'
+import { isPromise } from './PromiseUtils'
 
 function getComponentsForRoute(nextState, route, callback) {
   if (route.component || route.components) {
@@ -8,7 +9,13 @@ function getComponentsForRoute(nextState, route, callback) {
 
   const getComponent = route.getComponent || route.getComponents
   if (getComponent) {
-    getComponent.call(route, nextState, callback)
+    const componentReturn = getComponent.call(route, nextState, callback)
+    if (isPromise(componentReturn))
+      componentReturn.then(
+        // Try module.default first in case of System.import
+        component => callback(null, component.default || component),
+        callback
+      ).catch(callback)
   } else {
     callback()
   }

--- a/modules/getComponents.js
+++ b/modules/getComponents.js
@@ -14,8 +14,10 @@ function getComponentsForRoute(nextState, route, callback) {
       componentReturn
         // Try module.default first in case of System.import and Babel 6
         .then(component => component.default || component)
-        .then(component => callback(null, component))
-        .catch(callback)
+        .then(
+          component => callback(null, component),
+          callback
+        )
   } else {
     callback()
   }

--- a/modules/getComponents.js
+++ b/modules/getComponents.js
@@ -12,7 +12,7 @@ function getComponentsForRoute(nextState, route, callback) {
     const componentReturn = getComponent.call(route, nextState, callback)
     if (isPromise(componentReturn))
       componentReturn
-        // Try module.default first in case of System.import
+        // Try module.default first in case of System.import and Babel 6
         .then(component => component.default || component)
         .then(component => callback(null, component))
         .catch(callback)

--- a/modules/getComponents.js
+++ b/modules/getComponents.js
@@ -13,7 +13,8 @@ function getComponentsForRoute(nextState, route, callback) {
     if (isPromise(componentReturn))
       componentReturn
         // Try module.default first in case of System.import
-        .then(component => callback(null, component.default || component))
+        .then(component => component.default || component)
+        .then(component => callback(null, component))
         .catch(callback)
   } else {
     callback()

--- a/modules/matchRoutes.js
+++ b/modules/matchRoutes.js
@@ -1,4 +1,5 @@
 import { loopAsync } from './AsyncUtils'
+import { isPromise } from './PromiseUtils'
 import { matchPattern } from './PatternUtils'
 import warning from './routerWarning'
 import { createRoutes } from './RouteUtils'
@@ -18,7 +19,7 @@ function getChildRoutes(route, location, paramNames, paramValues, callback) {
     params: createParams(paramNames, paramValues)
   }
 
-  route.getChildRoutes(partialNextState, (error, childRoutes) => {
+  const childRoutesReturn = route.getChildRoutes(partialNextState, (error, childRoutes) => {
     childRoutes = !error && createRoutes(childRoutes)
     if (sync) {
       result = [ error, childRoutes ]
@@ -27,6 +28,13 @@ function getChildRoutes(route, location, paramNames, paramValues, callback) {
 
     callback(error, childRoutes)
   })
+
+  if (isPromise(childRoutesReturn))
+    childRoutesReturn
+      // Try module.default first in case of System.import
+      .then(childRoutes => childRoutes.default || childRoutes)
+      .then(childRoutes => callback(null, createRoutes(childRoutes)))
+      .catch(callback)
 
   sync = false
   return result  // Might be undefined.
@@ -41,9 +49,16 @@ function getIndexRoute(route, location, paramNames, paramValues, callback) {
       params: createParams(paramNames, paramValues)
     }
 
-    route.getIndexRoute(partialNextState, (error, indexRoute) => {
+    const indexRoutesReturn = route.getIndexRoute(partialNextState, (error, indexRoute) => {
       callback(error, !error && createRoutes(indexRoute)[0])
     })
+
+    if (isPromise(indexRoutesReturn))
+      indexRoutesReturn
+        // Try module.default first in case of System.import
+        .then(indexRoute => indexRoute.default || indexRoute)
+        .then(indexRoute => callback(null, createRoutes(indexRoute)[0]))
+        .catch(callback)
   } else if (route.childRoutes) {
     const pathless = route.childRoutes.filter(childRoute => !childRoute.path)
 

--- a/modules/matchRoutes.js
+++ b/modules/matchRoutes.js
@@ -31,8 +31,6 @@ function getChildRoutes(route, location, paramNames, paramValues, callback) {
 
   if (isPromise(childRoutesReturn))
     childRoutesReturn
-      // Try module.default first in case of System.import and Babel 6
-      .then(childRoutes => childRoutes.default || childRoutes)
       .then(
         childRoutes => callback(null, createRoutes(childRoutes)),
         callback
@@ -57,8 +55,6 @@ function getIndexRoute(route, location, paramNames, paramValues, callback) {
 
     if (isPromise(indexRoutesReturn))
       indexRoutesReturn
-        // Try module.default first in case of System.import and Babel 6
-        .then(indexRoute => indexRoute.default || indexRoute)
         .then(
           indexRoute => callback(null, createRoutes(indexRoute)[0]),
           callback

--- a/modules/matchRoutes.js
+++ b/modules/matchRoutes.js
@@ -31,7 +31,7 @@ function getChildRoutes(route, location, paramNames, paramValues, callback) {
 
   if (isPromise(childRoutesReturn))
     childRoutesReturn
-      // Try module.default first in case of System.import
+      // Try module.default first in case of System.import and Babel 6
       .then(childRoutes => childRoutes.default || childRoutes)
       .then(childRoutes => callback(null, createRoutes(childRoutes)))
       .catch(callback)
@@ -55,7 +55,7 @@ function getIndexRoute(route, location, paramNames, paramValues, callback) {
 
     if (isPromise(indexRoutesReturn))
       indexRoutesReturn
-        // Try module.default first in case of System.import
+        // Try module.default first in case of System.import and Babel 6
         .then(indexRoute => indexRoute.default || indexRoute)
         .then(indexRoute => callback(null, createRoutes(indexRoute)[0]))
         .catch(callback)

--- a/modules/matchRoutes.js
+++ b/modules/matchRoutes.js
@@ -33,8 +33,10 @@ function getChildRoutes(route, location, paramNames, paramValues, callback) {
     childRoutesReturn
       // Try module.default first in case of System.import and Babel 6
       .then(childRoutes => childRoutes.default || childRoutes)
-      .then(childRoutes => callback(null, createRoutes(childRoutes)))
-      .catch(callback)
+      .then(
+        childRoutes => callback(null, createRoutes(childRoutes)),
+        callback
+      )
 
   sync = false
   return result  // Might be undefined.
@@ -57,8 +59,10 @@ function getIndexRoute(route, location, paramNames, paramValues, callback) {
       indexRoutesReturn
         // Try module.default first in case of System.import and Babel 6
         .then(indexRoute => indexRoute.default || indexRoute)
-        .then(indexRoute => callback(null, createRoutes(indexRoute)[0]))
-        .catch(callback)
+        .then(
+          indexRoute => callback(null, createRoutes(indexRoute)[0]),
+          callback
+        )
   } else if (route.childRoutes) {
     const pathless = route.childRoutes.filter(childRoute => !childRoute.path)
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-dev-expression": "^0.2.1",
     "babel-plugin-istanbul": "^1.0.3",
+    "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "^6.13.2",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-1": "^6.13.0",

--- a/tests.webpack.js
+++ b/tests.webpack.js
@@ -1,5 +1,6 @@
 /* eslint-env mocha */
 
+import 'babel-polyfill'
 import expect from 'expect'
 
 import { _resetWarned } from './modules/routerWarning'


### PR DESCRIPTION
First pass at #3606. Not 100% happy with it right now. It would be easier to architect if we had guaranteed Promise availability, but alas... 

I've got some practical things in there for Babel's `default` exports. And we can't just accept a Promise instead of a function, since `System.import` won't code split in that case. That's probably the most ugly part of it.

But this works:
```jsx
<Route path='/' getComponent={() => System.import('./app')} />
```
![](http://img.pandawhale.com/post-19259-so-I-got-that-going-for-me-whi-CKYI.gif)