### PR TITLE
Readme: Add root path to Route component

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -244,7 +244,7 @@ be rendered by the parent route component with `this.props.children`.
 
 ```jsx
 const routes = (
-  <Route component={App}>
+  <Route path="/" component={App}>
     <Route path="groups" component={Groups} />
     <Route path="users" component={Users} />
   </Route>


### PR DESCRIPTION
Just getting started with React-Router, but thought it was a little unclear that the root URL isn't specified in the `Route` that renders the `App` component. While `/groups` and `/users` will still render correctly, navigating to the root URL '/' will give an error.