### PR TITLE
Allow a router prop to take priority over context prop.

### DIFF
--- a/modules/__tests__/withRouter-test.js
+++ b/modules/__tests__/withRouter-test.js
@@ -38,4 +38,25 @@ describe('withRouter', function () {
       done()
     })
   })
+
+  it('still uses router prop if provided', function (done) {
+    const Test = withRouter(function (props) {
+      props.test(props)
+      return null
+    })
+    const router = {
+      push() {},
+      replace() {},
+      go() {},
+      goBack() {},
+      goForward() {},
+      setRouteLeaveHook() {},
+      isActive() {}
+    }
+    const test = function (props) {
+      expect(props.router).toBe(router)
+    }
+
+    render(<Test router={router} test={test} />, node, done)
+  })
 })

--- a/modules/withRouter.js
+++ b/modules/withRouter.js
@@ -9,8 +9,10 @@ function getDisplayName(WrappedComponent) {
 export default function withRouter(WrappedComponent) {
   const WithRouter = React.createClass({
     contextTypes: { router: routerShape },
+    propTypes: { router: routerShape },
     render() {
-      return <WrappedComponent {...this.props} router={this.context.router} />
+      const router = this.props.router || this.context.router
+      return <WrappedComponent {...this.props} router={router} />
     }
   })
 


### PR DESCRIPTION
withRouter should allow a router prop specified on a wrapped component
to be used instead of the router in context; this pattern is more
flexible, avoids overwriting explicitly set props, and makes testing
components wrapped by withRouter more simple.