### PR TITLE
Fix auth-with-shared-route example

### DIFF
--- a/examples/auth-with-shared-root/components/About.js
+++ b/examples/auth-with-shared-root/components/About.js
@@ -6,4 +6,4 @@ const About = React.createClass({
   }
 })
 
-export default About
+module.exports = About

--- a/examples/auth-with-shared-root/components/App.js
+++ b/examples/auth-with-shared-root/components/App.js
@@ -44,4 +44,4 @@ const App = React.createClass({
 
 })
 
-export default App
+module.exports = App

--- a/examples/auth-with-shared-root/components/Dashboard.js
+++ b/examples/auth-with-shared-root/components/Dashboard.js
@@ -16,4 +16,4 @@ const Dashboard = React.createClass({
   }
 })
 
-export default Dashboard
+module.exports = Dashboard

--- a/examples/auth-with-shared-root/components/Landing.js
+++ b/examples/auth-with-shared-root/components/Landing.js
@@ -14,4 +14,4 @@ const Landing = React.createClass({
 
 })
 
-export default Landing
+module.exports = Landing

--- a/examples/auth-with-shared-root/components/Login.js
+++ b/examples/auth-with-shared-root/components/Login.js
@@ -44,4 +44,4 @@ const Login = React.createClass({
 
 })
 
-export default withRouter(Login)
+module.exports = withRouter(Login)

--- a/examples/auth-with-shared-root/components/Logout.js
+++ b/examples/auth-with-shared-root/components/Logout.js
@@ -11,4 +11,4 @@ const Logout = React.createClass({
   }
 })
 
-export default Logout
+module.exports = Logout

--- a/examples/auth-with-shared-root/components/PageOne.js
+++ b/examples/auth-with-shared-root/components/PageOne.js
@@ -6,4 +6,4 @@ const PageOne = React.createClass({
   }
 })
 
-export default PageOne
+module.exports = PageOne

--- a/examples/auth-with-shared-root/components/PageTwo.js
+++ b/examples/auth-with-shared-root/components/PageTwo.js
@@ -6,4 +6,4 @@ const PageTwo = React.createClass({
   }
 })
 
-export default PageTwo
+module.exports = PageTwo

--- a/examples/auth-with-shared-root/components/User.js
+++ b/examples/auth-with-shared-root/components/User.js
@@ -6,4 +6,4 @@ const User = React.createClass({
   }
 })
 
-export default User
+module.exports = User


### PR DESCRIPTION
Fix for the changed default export behavior in babel 6. The default export now needs to be explicitly required(). See also http://stackoverflow.com/questions/33505992/babel-6-changes-how-it-exports-default.

Had a look at the other examples, they're all ok.