### PR TITLE
Adding support to get the component instance that withRouter HOC wraps

### DIFF
--- a/modules/__tests__/withRouter-test.js
+++ b/modules/__tests__/withRouter-test.js
@@ -6,6 +6,7 @@ import Route from '../Route'
 import Router from '../Router'
 import routerShape from '../PropTypes'
 import withRouter from '../withRouter'
+
 describe('withRouter', function () {
   class App extends Component {
     propTypes: {

--- a/modules/__tests__/withRouter-test.js
+++ b/modules/__tests__/withRouter-test.js
@@ -31,7 +31,6 @@ describe('withRouter', function () {
   })
 
   it('puts router on context', function (done) {
-
     const WrappedApp = withRouter()(App)
 
     render((

--- a/modules/__tests__/withRouter-test.js
+++ b/modules/__tests__/withRouter-test.js
@@ -64,9 +64,7 @@ describe('withRouter', function () {
   })
 
   it('should support withRefs as a parameter', function (done) {
-    const WrappedApp = withRouter(App,{ 
-      withRef:true 
-    })
+    const WrappedApp = withRouter(App, { withRef:true })
     const router = {
       push() {},
       replace() {},

--- a/modules/__tests__/withRouter-test.js
+++ b/modules/__tests__/withRouter-test.js
@@ -12,9 +12,6 @@ describe('withRouter', function () {
     propTypes: {
       router: routerShape.isRequired
     }
-    testFunction() {
-      return 'hello from the test function'
-    }
     render() {
       expect(this.props.router).toExist()
       return <h1>App</h1>
@@ -31,7 +28,7 @@ describe('withRouter', function () {
   })
 
   it('puts router on context', function (done) {
-    const WrappedApp = withRouter()(App)
+    const WrappedApp = withRouter(App)
 
     render((
       <Router history={createHistory('/')}>
@@ -43,7 +40,7 @@ describe('withRouter', function () {
   })
 
   it('still uses router prop if provided', function (done) {
-    const Test = withRouter()(function (props) {
+    const Test = withRouter(function (props) {
       props.test(props)
       return null
     })
@@ -62,20 +59,4 @@ describe('withRouter', function () {
 
     render(<Test router={router} test={test} />, node, done)
   })
-
-  it('should support withRefs as a parameter',function (done) {
-    const WrappedApp = withRouter({ withRef:true })(App)
-    const router = {
-      push() {},
-      replace() {},
-      go() {},
-      goBack() {},
-      goForward() {},
-      setRouteLeaveHook() {},
-      isActive() {}
-    }
-    const component = render((<WrappedApp router={router}/>), node, done)
-    expect(component.getWrappedInstance().testFunction()).toEqual('hello from the test function')
-  })
-
 })

--- a/modules/__tests__/withRouter-test.js
+++ b/modules/__tests__/withRouter-test.js
@@ -63,8 +63,10 @@ describe('withRouter', function () {
     render(<Test router={router} test={test} />, node, done)
   })
 
-  it('should support withRefs as a parameter',function (done) {
-    const WrappedApp = withRouter(App,{ withRef:true })
+  it('should support withRefs as a parameter', function (done) {
+    const WrappedApp = withRouter(App,{ 
+      withRef:true 
+    })
     const router = {
       push() {},
       replace() {},

--- a/modules/__tests__/withRouter-test.js
+++ b/modules/__tests__/withRouter-test.js
@@ -12,6 +12,9 @@ describe('withRouter', function () {
     propTypes: {
       router: routerShape.isRequired
     }
+    testFunction() {
+      return 'hello from the test function'
+    }
     render() {
       expect(this.props.router).toExist()
       return <h1>App</h1>
@@ -58,5 +61,20 @@ describe('withRouter', function () {
     }
 
     render(<Test router={router} test={test} />, node, done)
+  })
+
+  it('should support withRefs as a parameter',function (done) {
+    const WrappedApp = withRouter(App,{ withRef:true })
+    const router = {
+      push() {},
+      replace() {},
+      go() {},
+      goBack() {},
+      goForward() {},
+      setRouteLeaveHook() {},
+      isActive() {}
+    }
+    const component = render((<WrappedApp router={router}/>), node, done)
+    expect(component.getWrappedInstance().testFunction()).toEqual('hello from the test function')
   })
 })

--- a/modules/__tests__/withRouter-test.js
+++ b/modules/__tests__/withRouter-test.js
@@ -6,11 +6,13 @@ import Route from '../Route'
 import Router from '../Router'
 import routerShape from '../PropTypes'
 import withRouter from '../withRouter'
-
 describe('withRouter', function () {
   class App extends Component {
     propTypes: {
       router: routerShape.isRequired
+    }
+    testFunction() {
+      return 'hello from the test function'
     }
     render() {
       expect(this.props.router).toExist()
@@ -28,7 +30,8 @@ describe('withRouter', function () {
   })
 
   it('puts router on context', function (done) {
-    const WrappedApp = withRouter(App)
+
+    const WrappedApp = withRouter()(App)
 
     render((
       <Router history={createHistory('/')}>
@@ -40,7 +43,7 @@ describe('withRouter', function () {
   })
 
   it('still uses router prop if provided', function (done) {
-    const Test = withRouter(function (props) {
+    const Test = withRouter()(function (props) {
       props.test(props)
       return null
     })
@@ -59,4 +62,20 @@ describe('withRouter', function () {
 
     render(<Test router={router} test={test} />, node, done)
   })
+
+  it('should support withRefs as a parameter',function (done) {
+    const WrappedApp = withRouter({ withRef:true })(App)
+    const router = {
+      push() {},
+      replace() {},
+      go() {},
+      goBack() {},
+      goForward() {},
+      setRouteLeaveHook() {},
+      isActive() {}
+    }
+    const component = render((<WrappedApp router={router}/>), node, done)
+    expect(component.getWrappedInstance().testFunction()).toEqual('hello from the test function')
+  })
+
 })

--- a/modules/withRouter.js
+++ b/modules/withRouter.js
@@ -1,23 +1,40 @@
 import React from 'react'
 import hoistStatics from 'hoist-non-react-statics'
 import { routerShape } from './PropTypes'
+import warning from './routerWarning'
 
 function getDisplayName(WrappedComponent) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component'
 }
+export default function withRouter(options) {
+  const wrapWithRouter = function (WrappedComponent) {
+    const WithRouter = React.createClass({
+      contextTypes: { router: routerShape },
+      propTypes: { router: routerShape },
+      getWrappedInstance() {
+        warning(options && options.withRef, 'To access the wrappedInstance you must provide {withRef : true} as the first argument of the withRouter call')
+        return this.refs.wrappedInstance
+      },
+      render() {
+        const router = this.props.router || this.context.router
+        if(options && options.withRef) {
+          return <WrappedComponent {...this.props} ref="wrappedInstance" router={router} />
+        }else{
+          return <WrappedComponent {...this.props} router={router} />
+        }
+      }
+    })
+    WithRouter.displayName = `withRouter(${getDisplayName(WrappedComponent)})`
+    WithRouter.WrappedComponent = WrappedComponent
 
-export default function withRouter(WrappedComponent) {
-  const WithRouter = React.createClass({
-    contextTypes: { router: routerShape },
-    propTypes: { router: routerShape },
-    render() {
-      const router = this.props.router || this.context.router
-      return <WrappedComponent {...this.props} router={router} />
-    }
-  })
+    return hoistStatics(WithRouter, WrappedComponent)
+  }
 
-  WithRouter.displayName = `withRouter(${getDisplayName(WrappedComponent)})`
-  WithRouter.WrappedComponent = WrappedComponent
-
-  return hoistStatics(WithRouter, WrappedComponent)
+  if(typeof(options) === 'function') {
+    warning(false,'passing a component to the first invocation of withRouter has been depreciated, withRouter'+ 
+    'now needs to be invoked twice, once to pass the options through, and a second time with the component eg. withRouter()(MyComponent) or withRouter({withRef:true})(MyComponent)')
+    return wrapWithRouter(options)
+  }else{
+    return wrapWithRouter
+  }
 }

--- a/modules/withRouter.js
+++ b/modules/withRouter.js
@@ -13,7 +13,7 @@ export default function withRouter(WrappedComponent, options) {
     contextTypes: { router: routerShape },
     propTypes: { router: routerShape },
     getWrappedInstance() {
-      warning(options && options.withRef, 'To access the wrappedInstance you must provide {withRef : true} as the first argument of the withRouter call')
+      warning(options && options.withRef, 'To access the wrappedInstance you must provide {withRef : true} as the second argument of the withRouter call')
       return this.refs.wrappedInstance
     },
     render() {

--- a/modules/withRouter.js
+++ b/modules/withRouter.js
@@ -14,13 +14,13 @@ export default function withRouter(WrappedComponent, options) {
     propTypes: { router: routerShape },
     getWrappedInstance() {
       warning(options && options.withRef, 'To access the wrappedInstance you must provide {withRef : true} as the second argument of the withRouter call')
-      return this.refs.wrappedInstance
+      return this._wrappedComponent
     },
     render() {
       const router = this.props.router || this.context.router
       if(options && options.withRef) {
-        return <WrappedComponent {...this.props} ref="wrappedInstance" router={router} />
-      }else{
+        return <WrappedComponent {...this.props} ref={(component)=>this._wrappedComponent = component} router={router} />
+      } else {
         return <WrappedComponent {...this.props} router={router} />
       }
     }

--- a/modules/withRouter.js
+++ b/modules/withRouter.js
@@ -1,18 +1,28 @@
 import React from 'react'
 import hoistStatics from 'hoist-non-react-statics'
 import { routerShape } from './PropTypes'
+import warning from './routerWarning'
+
 
 function getDisplayName(WrappedComponent) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component'
 }
 
-export default function withRouter(WrappedComponent) {
+export default function withRouter(WrappedComponent, options) {
   const WithRouter = React.createClass({
     contextTypes: { router: routerShape },
     propTypes: { router: routerShape },
+    getWrappedInstance() {
+      warning(options && options.withRef, 'To access the wrappedInstance you must provide {withRef : true} as the first argument of the withRouter call')
+      return this.refs.wrappedInstance
+    },
     render() {
       const router = this.props.router || this.context.router
-      return <WrappedComponent {...this.props} router={router} />
+      if(options && options.withRef) {
+        return <WrappedComponent {...this.props} ref="wrappedInstance" router={router} />
+      }else{
+        return <WrappedComponent {...this.props} router={router} />
+      }
     }
   })
 

--- a/modules/withRouter.js
+++ b/modules/withRouter.js
@@ -1,40 +1,23 @@
 import React from 'react'
 import hoistStatics from 'hoist-non-react-statics'
 import { routerShape } from './PropTypes'
-import warning from './routerWarning'
 
 function getDisplayName(WrappedComponent) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component'
 }
-export default function withRouter(options) {
-  const wrapWithRouter = function (WrappedComponent) {
-    const WithRouter = React.createClass({
-      contextTypes: { router: routerShape },
-      propTypes: { router: routerShape },
-      getWrappedInstance() {
-        warning(options && options.withRef, 'To access the wrappedInstance you must provide {withRef : true} as the first argument of the withRouter call')
-        return this.refs.wrappedInstance
-      },
-      render() {
-        const router = this.props.router || this.context.router
-        if(options && options.withRef) {
-          return <WrappedComponent {...this.props} ref="wrappedInstance" router={router} />
-        }else{
-          return <WrappedComponent {...this.props} router={router} />
-        }
-      }
-    })
-    WithRouter.displayName = `withRouter(${getDisplayName(WrappedComponent)})`
-    WithRouter.WrappedComponent = WrappedComponent
 
-    return hoistStatics(WithRouter, WrappedComponent)
-  }
+export default function withRouter(WrappedComponent) {
+  const WithRouter = React.createClass({
+    contextTypes: { router: routerShape },
+    propTypes: { router: routerShape },
+    render() {
+      const router = this.props.router || this.context.router
+      return <WrappedComponent {...this.props} router={router} />
+    }
+  })
 
-  if(typeof(options) === 'function') {
-    warning(false,'passing a component to the first invocation of withRouter has been depreciated, withRouter'+ 
-    'now needs to be invoked twice, once to pass the options through, and a second time with the component eg. withRouter()(MyComponent) or withRouter({withRef:true})(MyComponent)')
-    return wrapWithRouter(options)
-  }else{
-    return wrapWithRouter
-  }
+  WithRouter.displayName = `withRouter(${getDisplayName(WrappedComponent)})`
+  WithRouter.WrappedComponent = WrappedComponent
+
+  return hoistStatics(WithRouter, WrappedComponent)
 }

--- a/modules/withRouter.js
+++ b/modules/withRouter.js
@@ -18,7 +18,7 @@ export default function withRouter(WrappedComponent, options) {
     },
     render() {
       const router = this.props.router || this.context.router
-      if(options && options.withRef) {
+      if (options && options.withRef) {
         return <WrappedComponent {...this.props} ref={(component)=>this._wrappedComponent = component} router={router} />
       } else {
         return <WrappedComponent {...this.props} router={router} />


### PR DESCRIPTION
Following up on conversation from [this](https://github.com/reactjs/react-router/issues/3652) bug. Adding the ability to specify an withRef option to be passed to withRouter. The signature has changed from `withRouter(MyComponent)` to `withRouter()(MyComponent)` except now you can do this `withRouter({withRef:true})(MyComponent)` and later `instanceOfMyComponent.getWrappedInstance()` returning the component instance wrapped by withRouter. This feature is also demonstrated in react-redux in [code](https://github.com/reactjs/react-redux/blob/master/src/components/connect.js#L265) and is [documented](https://github.com/reactjs/react-redux/blob/master/docs/api.md#getwrappedinstance-reactcomponent). If given the thumbs up I will update the documentation, and write a codemod script.