### PR TITLE
Feature/link-replace

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -128,6 +128,9 @@ A custom handler for the click event. Works just like a handler on an `<a>` tag 
 ##### `onlyActiveOnIndex`
 If `true`, the `<Link>` will only be active when the current route exactly matches the linked route.
 
+##### `action`
+Must be either `push` or `replace`. The `<Link>` will execute the history action of choice. (default is `push`)
+
 ##### *others*
 You can also pass props you'd like to be on the `<a>` such as a `title`, `id`, `className`, etc.
 

--- a/modules/Link.js
+++ b/modules/Link.js
@@ -3,7 +3,7 @@ import warning from './routerWarning'
 import invariant from 'invariant'
 import { routerShape } from './PropTypes'
 
-const { bool, object, string, func, oneOfType } = React.PropTypes
+const { bool, object, string, func, oneOf, oneOfType } = React.PropTypes
 
 function isLeftClickEvent(event) {
   return event.button === 0
@@ -47,6 +47,14 @@ function createLocationDescriptor(to, { query, hash, state }) {
  * in the state/query props, respectively.
  *
  *   <Link ... query={{ show: true }} state={{ the: 'state' }} />
+ *
+ * By default, Links will push to history as usual, but you can instruct
+ * them to replace history state instead by providing an action prop equal
+ * to 'replace'
+ *
+ * <Link to={`/posts/${post.id}`} />
+ * <Link to={`/posts/${post.id}`} action="replace" />
+ *
  */
 const Link = React.createClass({
 
@@ -62,6 +70,7 @@ const Link = React.createClass({
     activeStyle: object,
     activeClassName: string,
     onlyActiveOnIndex: bool.isRequired,
+    action: oneOf(['push','replace']).isRequired,
     onClick: func,
     target: string
   },
@@ -69,6 +78,7 @@ const Link = React.createClass({
   getDefaultProps() {
     return {
       onlyActiveOnIndex: false,
+      action: 'push',
       style: {}
     }
   },
@@ -98,7 +108,8 @@ const Link = React.createClass({
     const { to, query, hash, state } = this.props
     const location = createLocationDescriptor(to, { query, hash, state })
 
-    this.context.router.push(location)
+    // from enum we know it can only be 'push' or 'replace'
+    this.context.router[this.props.action](location)
   },
 
   render() {

--- a/modules/Link.js
+++ b/modules/Link.js
@@ -70,7 +70,7 @@ const Link = React.createClass({
     activeStyle: object,
     activeClassName: string,
     onlyActiveOnIndex: bool.isRequired,
-    action: oneOf(['push','replace']).isRequired,
+    action: oneOf([ 'push','replace' ]).isRequired,
     onClick: func,
     target: string
   },

--- a/modules/__tests__/Link-test.js
+++ b/modules/__tests__/Link-test.js
@@ -453,6 +453,85 @@ describe('A <Link>', function () {
         </Router>
       ), node, execNextStep)
     })
+
+    it('transition by push to the correct route', function (done) {
+      class LinkWrapper extends Component {
+        render() {
+          return (
+            <Link to="/hello?the=query#hash" action="push">
+              Link
+            </Link>
+          )
+        }
+      }
+
+      const history = createHistory('/')
+      const spy = spyOn(history, 'push').andCallThrough()
+
+      const steps = [
+        function () {
+          click(node.querySelector('a'), { button: 0 })
+        },
+        function () {
+          expect(node.innerHTML).toMatch(/Hello/)
+          expect(spy).toHaveBeenCalled()
+
+          const { location } = this.state
+          expect(location.pathname).toEqual('/hello')
+          expect(location.search).toEqual('?the=query')
+          expect(location.hash).toEqual('#hash')
+        }
+      ]
+
+      const execNextStep = execSteps(steps, done)
+
+      render((
+        <Router history={history} onUpdate={execNextStep}>
+          <Route path="/" component={LinkWrapper} />
+          <Route path="/hello" component={Hello} />
+        </Router>
+      ), node, execNextStep)
+    })
+
+    it('transition by replace to the correct route', function (done) {
+      class LinkWrapper extends Component {
+        render() {
+          return (
+            <Link to="/hello?the=query#hash" action="replace">
+              Link
+            </Link>
+          )
+        }
+      }
+
+      const history = createHistory('/')
+      const spy = spyOn(history, 'replace').andCallThrough()
+
+      const steps = [
+        function () {
+          click(node.querySelector('a'), { button: 0 })
+        },
+        function () {
+          expect(node.innerHTML).toMatch(/Hello/)
+          expect(spy).toHaveBeenCalled()
+
+          const { location } = this.state
+          expect(location.pathname).toEqual('/hello')
+          expect(location.search).toEqual('?the=query')
+          expect(location.hash).toEqual('#hash')
+        }
+      ]
+
+      const execNextStep = execSteps(steps, done)
+
+      render((
+        <Router history={history} onUpdate={execNextStep}>
+          <Route path="/" component={LinkWrapper} />
+          <Route path="/hello" component={Hello} />
+        </Router>
+      ), node, execNextStep)
+    })
+
   })
 
 })


### PR DESCRIPTION
Hello,

I have the current feature in my project where a bunch of links should replace history entry instead of pushing into it. I know i could have made an entire custom history, but it looked overkill when a simple variation in the Link component could have done it properly, so i added an optional prop named `action` which default is `push` (so it's non-breaking) and can also be set to `replace` (thanks to propTypes.oneOf).

At first it felt out of place for me to have this because the links are now manipulating the history directly. But after thinking further, they actually did it already, with a single method instead of many, meaning the coupling to the history object has not increased _that much_.

I'd be pleased to answer any questions,

Thanks