### PR TITLE
Removes deprecated replaceState with replace in the routeConfig readme

### DIFF
--- a/docs/guides/basics/RouteConfiguration.md
+++ b/docs/guides/basics/RouteConfiguration.md
@@ -194,7 +194,7 @@ const routeConfig = [
           { path: '/messages/:id', component: Message },
           { path: 'messages/:id',
             onEnter: function (nextState, replaceState) {
-              replaceState(null, '/messages/' + nextState.params.id)
+              replace(null, '/messages/' + nextState.params.id)
             }
           }
         ]


### PR DESCRIPTION
replaceState(state, pathname, query) deprecated use replace(location)

```
browser.js:49 Warning: [react-router] `replaceState(state, pathname, query) is deprecated; use `replace(location)` with a location descriptor instead. http://tiny.cc/router-isActivedeprecated
```