### PR TITLE
Remove broken link in API doc

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -534,7 +534,7 @@ A route's component is rendered when that route matches the URL. The router will
 ### Injected Props
 
 #### `location`
-The current location.
+The current [location](https://github.com/mjackson/history/blob/v2.x/docs/Location.md).
 
 #### `params`
 The dynamic segments of the URL.

--- a/docs/API.md
+++ b/docs/API.md
@@ -534,7 +534,7 @@ A route's component is rendered when that route matches the URL. The router will
 ### Injected Props
 
 #### `location`
-The current [location](https://github.com/reactjs/history/blob/master/docs/Location.md).
+The current location.
 
 #### `params`
 The dynamic segments of the URL.


### PR DESCRIPTION
The [history](https://github.com/mjackson/history) Location doc [was removed](https://github.com/mjackson/history/commit/fc46b329ba58289e447d3fe8997a9d6e1ccc962e).