### PR TITLE
Use replace instead of transitionTo for redirects

### DIFF
--- a/modules/createTransitionManager.js
+++ b/modules/createTransitionManager.js
@@ -268,7 +268,7 @@ export default function createTransitionManager(history, routes) {
           if (error) {
             listener(error)
           } else if (redirectLocation) {
-            history.transitionTo(redirectLocation)
+            history.replace(redirectLocation)
           } else if (nextState) {
             listener(null, nextState)
           } else {


### PR DESCRIPTION
This just reduces the surface area of history that we use.