### PR TITLE
Corrected misleading routeParams docs comment.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -544,7 +544,7 @@ The dynamic segments of the URL.
 The route that rendered this component.
 
 #### `routeParams`
-A subset of `this.props.params` that were directly specified in this component's route. For example, if the route's path is `users/:userId` and the URL is `/users/123/portfolios/345` then `this.props.routeParams` will be `{userId: '123'}`, and `this.props.params` will be `{userId: '123', portfolioId: 345}`.
+A subset of `this.props.params` that were directly specified in this component's route. For example, if the route's path is `users/:userId` and the URL is `/users/123/portfolios/345` then `this.props.routeParams` will be `{userId: '123'}`, and `this.props.params` will be `{userId: '123', portfolioId: '345'}`.
 
 #### `children`
 The matched child route element to be rendered. If the route has [named components](/docs/API.md#named-components) then this will be undefined, and the components will instead be available as direct properties on `this.props`.


### PR DESCRIPTION
The actual type of this.props.params.portfolioId will be a string as opposed to a number.